### PR TITLE
FORGE-1026 Fixed Method.getQualifiedReturnType()

### DIFF
--- a/impl/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
@@ -317,7 +317,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       // Check for direct import matches first since they are the fastest and least work-intensive
       if (Types.isSimpleName(result))
       {
-         if (!hasImport(type) && Types.isJavaLang(type))
+         if (!hasImport(result) && Types.isJavaLang(result))
          {
             result = "java.lang." + result;
          }

--- a/impl/src/main/java/org/jboss/forge/parser/java/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/parser/java/impl/MethodImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -235,6 +236,17 @@ public class MethodImpl<O extends JavaSource<O>> implements Method<O>
       }
 
       result = parent.resolveType(result);
+      if (returnType != null && returnType.isArrayType())
+      {
+         // FIXME: This is a hack and needs fixing in the design of the Forge parser.
+         // The resolved type lacks information about arrays since arrays would be stripped from it
+         // We recreate it using the dimensions in the JDT Type to ensure that arrays are not lost in the return type.
+         int dimensions = ((ArrayType) returnType).getDimensions();
+         for (int ctr = 0; ctr < dimensions; ctr++)
+         {
+            result += "[]";
+         }
+      }
 
       return result;
    }

--- a/impl/src/test/java/org/jboss/forge/test/parser/java/MethodReturnTypeTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/parser/java/MethodReturnTypeTest.java
@@ -38,6 +38,81 @@ public class MethodReturnTypeTest
    }
 
    @Test
+   public void testGetQualifiedReturnTypePrimitiveArray() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class).addMethod("public long[] getLongArray()");
+      Assert.assertEquals("long[]", method.getQualifiedReturnType());
+   }
+
+   @Test
+   public void testGetQualifiedReturnTypeObjectArray() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class).addMethod("public Long[] getLongArray()");
+      Assert.assertEquals("java.lang.Long[]", method.getQualifiedReturnType());
+   }
+
+   @Test
+   public void testGetQualifiedReturnTypeNDimensionObjectArray() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class).addMethod("public Long[][] getLongArray()");
+      Assert.assertEquals("java.lang.Long[][]", method.getQualifiedReturnType());
+   }
+
+   @Test
+   public void testGetQualifiedReturnTypeObjectArrayOfImportedType() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class).addMethod("public List[] getListArray()");
+      method.getOrigin().addImport(List.class);
+      Assert.assertEquals("java.util.List[]", method.getQualifiedReturnType());
+   }
+
+   @Test
+   public void testGetQualifiedReturnTypeImportedObjectArrayParameterizedImportedType() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class).addMethod("public List<Long>[] getListArray()");
+      method.getOrigin().addImport(List.class);
+      Assert.assertEquals("java.util.List[]", method.getQualifiedReturnType());
+   }
+
+   @Test
+   public void testGetReturnTypePrimitiveObjectArray() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class)
+               .addMethod("public long[] getList(return null;)");
+      method.getOrigin().addImport(List.class);
+      Type<JavaClass> type = method.getReturnTypeInspector();
+      Assert.assertEquals("long", type.getQualifiedName());
+      Assert.assertFalse(type.isParameterized());
+      Assert.assertFalse(type.isWildcard());
+      Assert.assertTrue(type.isPrimitive());
+      Assert.assertFalse(type.isQualified());
+      Assert.assertTrue(type.isArray());
+
+      List<Type<JavaClass>> arguments = type.getTypeArguments();
+
+      Assert.assertEquals(0, arguments.size());
+   }
+
+   @Test
+   public void testGetReturnTypeBoxedObjectArray() throws Exception
+   {
+      Method<JavaClass> method = JavaParser.create(JavaClass.class)
+               .addMethod("public Long[] getList(return null;)");
+      method.getOrigin().addImport(List.class);
+      Type<JavaClass> type = method.getReturnTypeInspector();
+      Assert.assertEquals("java.lang.Long", type.getQualifiedName());
+      Assert.assertFalse(type.isParameterized());
+      Assert.assertFalse(type.isWildcard());
+      Assert.assertFalse(type.isPrimitive());
+      Assert.assertFalse(type.isQualified());
+      Assert.assertTrue(type.isArray());
+
+      List<Type<JavaClass>> arguments = type.getTypeArguments();
+
+      Assert.assertEquals(0, arguments.size());
+   }
+
+   @Test
    public void testGetReturnTypeObjectArray() throws Exception
    {
       Method<JavaClass> method = JavaParser.create(JavaClass.class)


### PR DESCRIPTION
The fix ensures that ArrayTypes are not converted into plain SimpleTypes when the method return type is parsed.
