### PR TITLE
FORGE-1086 Fixed Field.getQualifiedType()

### DIFF
--- a/impl/src/main/java/org/jboss/forge/parser/java/impl/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/forge/parser/java/impl/FieldImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
@@ -298,8 +299,19 @@ public class FieldImpl<O extends JavaSource<O>> implements Field<O>
    @Override
    public String getQualifiedType()
    {
-      Object type = field.getStructuralProperty(FieldDeclaration.TYPE_PROPERTY);
-      return parent.resolveType(type.toString());
+      Type fieldType = field.getType();
+      String result = parent.resolveType(fieldType.toString());
+      if (fieldType != null && fieldType.isArrayType())
+      {
+         // The resolved type lacks information about arrays since arrays would be stripped from it
+         // We recreate it using the dimensions in the JDT Type to ensure that arrays are not lost in the return type.
+         int dimensions = ((ArrayType) fieldType).getDimensions();
+         for (int ctr = 0; ctr < dimensions; ctr++)
+         {
+            result += "[]";
+         }
+      }
+      return result;
    }
 
    @Override

--- a/impl/src/test/java/org/jboss/forge/test/parser/java/FieldTypeTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/parser/java/FieldTypeTest.java
@@ -211,7 +211,7 @@ public class FieldTypeTest
       final Field<JavaClass> field = javaClass.addField();
       field.setName("content");
       field.setType(byte[].class);
-      Assert.assertEquals("byte", field.getQualifiedType());
+      Assert.assertEquals("byte[]", field.getQualifiedType());
       Assert.assertTrue(field.getTypeInspector().isArray());
    }
 
@@ -222,7 +222,7 @@ public class FieldTypeTest
       final Field<JavaClass> field = javaClass.addField();
       field.setName("content");
       field.setType(byte[][][].class);
-      Assert.assertEquals("byte", field.getQualifiedType());
+      Assert.assertEquals("byte[][][]", field.getQualifiedType());
       Type<JavaClass> typeInspector = field.getTypeInspector();
       Assert.assertTrue(typeInspector.isArray());
       Assert.assertEquals(3, typeInspector.getArrayDimensions());
@@ -236,10 +236,10 @@ public class FieldTypeTest
       final Field<JavaClass> field = javaClass.addField();
       field.setName("content");
       field.setType(java.util.Vector[][][].class);
-      Assert.assertEquals("java.util.Vector", field.getQualifiedType());
+      Assert.assertEquals("java.util.Vector[][][]", field.getQualifiedType());
       Type<JavaClass> typeInspector = field.getTypeInspector();
       Assert.assertTrue(typeInspector.isArray());
       Assert.assertEquals(3, typeInspector.getArrayDimensions());
-      Assert.assertEquals("Vector", field.getType());
+      Assert.assertEquals("Vector[][][]", field.getType());
    }
 }


### PR DESCRIPTION
The fix ensures that ArrayTypes are not converted into plain SimpleTypes when the field type is parsed.
