### PR TITLE
FORGE-1096 Fixed spurious ArrayIndexOutOfBoundsException.

### DIFF
--- a/impl/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
@@ -9,8 +9,10 @@ package org.jboss.forge.parser.java.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
@@ -23,6 +25,7 @@ import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jface.text.Document;
 import org.eclipse.text.edits.TextEdit;
 import org.jboss.forge.parser.JavaParser;
@@ -622,7 +625,11 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
 
       try
       {
-         TextEdit edit = unit.rewrite(document, null);
+         @SuppressWarnings("rawtypes")
+         Map options = JavaCore.getOptions();
+         options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
+         options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
+         TextEdit edit = unit.rewrite(document, options);
          edit.apply(document);
       }
       catch (Exception e)

--- a/impl/src/test/java/org/jboss/forge/test/parser/java/JavaSourceCompatibilityTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/parser/java/JavaSourceCompatibilityTest.java
@@ -13,6 +13,7 @@ public class JavaSourceCompatibilityTest {
 		JavaSource<?> source = JavaParser.parse("public class Test{public void test() {java.util.List<String> s = new java.util.ArrayList<String>(); for (String item : s){}}}");
 		Assert.assertFalse(source.hasSyntaxErrors());
 	}
+	
 	@Test
 	public void testSupportsGenericsSourceFromConstructor() throws Exception {
 		JavaSource<?> source = JavaParser.parse("public class Test{public Test() {java.util.List<String> s = new java.util.ArrayList<String>(); for (String item : s){}}}");
@@ -25,4 +26,24 @@ public class JavaSourceCompatibilityTest {
 		source.addMethod("public void test() {java.util.List<String> s = new java.util.ArrayList<String>(); for (String item : s){}}");
 		Assert.assertFalse(source.hasSyntaxErrors());
 	}
+	
+	@Test
+   public void testSupportsGenericsSourceFromAddedConstructor() throws Exception {
+      JavaClass source = JavaParser.parse(JavaClass.class, "public class Test{}");
+      // Add a new method to get JDT to recognize the new ASTs
+      source.addMethod().setConstructor(true).setBody("java.util.List<String> s = new java.util.ArrayList<String>(); for (String item : s){}");
+      // Forces a rewrite to happen via AbstractJavaSource
+      source.toString();
+      Assert.assertFalse(source.hasSyntaxErrors());
+   }
+	
+	@Test
+   public void testSupportsGenericsSourceFromAddedMethod() throws Exception {
+      JavaClass source = JavaParser.parse(JavaClass.class, "public class Test{}");
+      // Add a new method to get JDT to recognize the new ASTs
+      source.addMethod().setName("test").setBody("java.util.List<String> s = new java.util.ArrayList<String>(); for (String item : s){}");
+      // Forces a rewrite to happen via AbstractJavaSource
+      source.toString();
+      Assert.assertFalse(source.hasSyntaxErrors());
+   }
 }


### PR DESCRIPTION
The exception was thrown on rewriting the CompilationUnit, and
was most likely caused due to use of a lower source level.

Setting the source level to 1.7 gets rid of the exception.
