### PR TITLE
JDK 1.6 compatibility changes

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/PropertyImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/PropertyImpl.java
@@ -9,8 +9,8 @@ package org.jboss.forge.roaster.model.impl;
 
 import java.text.ParsePosition;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -427,7 +427,9 @@ class PropertyImpl<O extends JavaSource<O> & PropertyHolderSource<O>> implements
    @Override
    public String toString()
    {
-      return "Property " + Objects.toString(name, "<missing>");
+      // incompatible with java 6: 
+      // return "Property " + Objects.toString(name, "<missing>");
+      return "Property: " + ((name != null) ? name.toString() : "<missing>");
    }
 
    @Override
@@ -448,7 +450,10 @@ class PropertyImpl<O extends JavaSource<O> & PropertyHolderSource<O>> implements
    @Override
    public int hashCode()
    {
-      return Objects.hash(getOrigin(), getName());
+      // incompatible with java 6: 
+      // return Objects.hash(getOrigin(), getName());
+      Object [] values = { getOrigin(), getName() };
+      return Arrays.hashCode(values);
    }
 
    /**
@@ -560,7 +565,7 @@ class PropertyImpl<O extends JavaSource<O> & PropertyHolderSource<O>> implements
    @Override
    public List<? extends Annotation<O>> getAnnotations()
    {
-      List<Annotation<O>> annotations = new ArrayList<>();
+      List<Annotation<O>> annotations = new ArrayList<Annotation<O>>();
       FieldSource<O> field = getField();
       if (field != null)
       {

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
       <maven>3.0</maven>
    </prerequisites>
 
+  <properties>
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+  </properties>
+
    <modules>
       <module>api</module>
       <module>impl</module>


### PR DESCRIPTION
Changes necessary to create Java 6 compatible roaster artifacts. 

What's a little weird is that the project still needs to be compiled using a Java **7** compiler. As far as I can tell, this is because the type variable least-upper bound logic (for classes like `AbstractGenericCapableJavaSource<O extends JavaSource<O> & PropertyHolderSource<O>>`) in the Java 6 compiler can't deal with the recursive structure in roaster-impl created by classes like  `JavaSource<T extends JavaSource<T>>`. 

The Java 6 compiler will throw an OutOfMemoryError (complaining about either the GC Overhead limit or lack of heap space, depending on your options) with the top of the stack listing the `merge`, `intersect` and of course `lub` methods in `com.sun.tools.javac.code.Types`. The Java 7 compiler will quickly and happily complete. 
