### PR TITLE
Fix to avoid NPE when a field don't have initializer and field.getString...

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
@@ -382,15 +382,15 @@ public class FieldImpl<O extends JavaSource<O>> implements FieldSource<O>
    @Override
    public String getLiteralInitializer()
    {
-      String result = fragment.getInitializer().toString();
-      return result;
+      Expression expression = fragment.getInitializer();
+      return expression != null ? expression.toString() : null;
    }
 
    @Override
    public String getStringInitializer()
    {
-      String result = Strings.unquote(fragment.getInitializer().toString());
-      return result;
+      Expression expression = fragment.getInitializer();
+      return expression != null ? Strings.unquote(expression.toString()) : null;
    }
 
    @Override


### PR DESCRIPTION
A NPE was produced when getStringInitializer() or getLiteralInitializer() was invoked on fields that don't have initializer.
The expected behaviour is that if the field don't have initializer null will be returned.
