### PR TITLE
Preserve generics in method parameters

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -268,6 +268,11 @@ public class Types
 
    public static String stripGenerics(final String type)
    {
+       return fixArray( type, true );
+   }
+
+   public static String fixArray(final String type, boolean stripGenerics)
+   {
       final String componentType;
       final int arrayDimensions;
       if (isArray(type))
@@ -281,7 +286,7 @@ public class Types
          componentType = type;
       }
       final StringBuilder result = new StringBuilder();
-      if (isGeneric(componentType))
+      if (isGeneric(componentType) && stripGenerics)
       {
          result.append(componentType.replaceFirst("^([^<]*)<.*?>$", "$1"));
       }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -681,7 +681,7 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
       {
          getOrigin().addImport(type);
       }
-      String stub = "public class Stub { public void method( " + Types.toSimpleName(Types.stripGenerics(type)) + " "
+      String stub = "public class Stub { public void method( " + Types.toSimpleName(Types.fixArray(type,false)) + " "
                + name + " ) {} }";
       JavaClassSource temp = (JavaClassSource) Roaster.parse(stub);
       List<MethodSource<JavaClassSource>> methods = temp.getMethods();

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodSignatureTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodSignatureTest.java
@@ -125,4 +125,37 @@ public class MethodSignatureTest
    {
       Assert.assertEquals(visibility, method.getVisibility().toString());
    }
+
+   @Test
+   public void testMethodWithGenericParameters() throws Exception
+   {
+      JavaClassSource javaClass = Roaster.create(JavaClassSource.class);
+      MethodSource<JavaClassSource> method = javaClass.addMethod().setPublic().setName( "hello" ).setReturnType( "java.util.List<String>" );
+      method.addParameter( "java.util.Map<java.util.Set<String>,Object>", "map" );
+
+      String signature = method.toSignature();
+      assertEquals( "public hello(Map) : List", signature );
+
+      ParameterSource ps = method.getParameters().get( 0 );
+      assertEquals( 2, ps.getType().getTypeArguments().size() );
+
+      assertEquals( 1, method.getReturnType().getTypeArguments().size() );
+   }
+
+   @Test
+   public void testMethodSignatureParamsWithGenerics() throws Exception
+   {
+      MethodSource<JavaClassSource> method = Roaster.create(JavaClassSource.class).addMethod(
+              "public java.util.List<String> hello(java.util.Map<java.util.Set<String>,Object> map)");
+      String signature = method.toSignature();
+      assertEquals( "public hello(java.util.Map) : java.util.List", signature );
+
+      ParameterSource ps = method.getParameters().get( 0 );
+      assertEquals( 2, ps.getType().getTypeArguments().size() );
+
+      assertEquals( "public java.util.List<String> hello(java.util.Map<java.util.Set<String>,Object> map){\n}",
+                    method.toString().trim());
+      assertEquals( 1, method.getReturnType().getTypeArguments().size() );
+   }
+
 }


### PR DESCRIPTION
Roaster.parse preserves the type parameters of a method argument.
However, if a parameter is added directly using method.addParameter, generics are stripped