### PR TITLE
Qualify inner classes correctly

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -664,7 +664,7 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    @Override
    public ParameterSource<O> addParameter(Class<?> type, String name)
    {
-      return addParameter(type.getName(), name);
+      return addParameter(type.getCanonicalName(), name);
    }
 
    @Override

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodSignatureTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodSignatureTest.java
@@ -125,4 +125,18 @@ public class MethodSignatureTest
    {
       Assert.assertEquals(visibility, method.getVisibility().toString());
    }
+
+   public static class Inner {}
+
+   @Test
+   public void testMethodWithInnerClassParameter() throws Exception
+   {
+      JavaClassSource javaClass = Roaster.create(JavaClassSource.class);
+      MethodSource<JavaClassSource> method = javaClass.addMethod().setPublic().setName("doSomething").setReturnTypeVoid();
+      method.addParameter(Inner.class, "inner");
+      Assert.assertEquals(1, javaClass.getMethods().size());
+      assertEquals( Inner.class.getCanonicalName(), method.getParameters().get( 0 ).getType().getQualifiedName() );
+      assertEquals( Inner.class.getCanonicalName(), javaClass.getImports().get( 0 ).getQualifiedName() );
+   }
+
 }


### PR DESCRIPTION
avoid qualified names using "$".
Note: there may be other places where this problem happens