### PR TITLE
ROASTER-72 Adds a new API to parse the multiple declarations of type in a file.

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/Roaster.java
+++ b/api/src/main/java/org/jboss/forge/roaster/Roaster.java
@@ -20,6 +20,7 @@ import java.util.ServiceLoader;
 
 import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
 import org.jboss.forge.roaster.spi.FormatterProvider;
 import org.jboss.forge.roaster.spi.JavaParser;
 
@@ -191,6 +192,41 @@ public final class Roaster
          }
       }
       throw new ParserException("Cannot find JavaParserProvider capable of parsing the requested data");
+   }
+   
+   /**
+    * Read the given {@link InputStream} and parse its data into a source code file structure which contains
+    * a List of  new {@link JavaType} instances of the given type.
+    * The caller is responsible for closing the stream.
+    */
+   @Deprecated
+   public static JavaSourceUnit parse2(String encoding_if_its_string, final InputStream data)
+   {
+      for (JavaParser parser : getParsers())
+      {
+         final JavaSourceUnit sources = parser.parse( encoding_if_its_string, data);
+
+         if ( sources != null ) return sources;
+      }
+      throw new ParserException("Cannot find JavaParserProvider capable of parsing the requested data");
+   }
+   
+   /**
+    * Try to cast the 'source' object into the type of 'type'.
+    *
+    * @param source
+    * @param type
+    * @return
+    * @throws ParserException when the cast cannot be done for some reasons.
+    */
+   public static<T extends JavaType<?>> T tryCast( final JavaType<?> source, final Class<T> type ){
+       if (type.isInstance(source))
+       {
+          @SuppressWarnings("unchecked")
+          final T result = (T) source;
+          return result;
+       }
+       throw new ParserException("the [" + source.getClass().getSimpleName() + "] cannot be casted into [" + type.getSimpleName() + "]");
    }
 
    /**

--- a/api/src/main/java/org/jboss/forge/roaster/model/JavaType.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/JavaType.java
@@ -84,5 +84,11 @@ public interface JavaType<T extends JavaType<T>> extends
     */
    @Deprecated
    public List<? extends JavaType<?>> getNestedClasses();
+   
+   
+   /**
+    * ROAST-74 : emits the unformatted code.
+    */
+   public String toUnformattedString();
 
 }

--- a/api/src/main/java/org/jboss/forge/roaster/model/source/JavaSourceUnit.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/JavaSourceUnit.java
@@ -32,5 +32,7 @@ public interface JavaSourceUnit {
 	 * @return
 	 */
 	String toString();
+	
+	String toUnformattedString();
 
 }

--- a/api/src/main/java/org/jboss/forge/roaster/model/source/JavaSourceUnit.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/JavaSourceUnit.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.roaster.model.source;
+
+import java.util.List;
+
+import org.jboss.forge.roaster.model.JavaType;
+
+public interface JavaSourceUnit {
+	
+	/**
+	 * A type in the source file governs the declaration environment such as 'package' and 'import' information.
+	 * 
+	 * @return basically the first element of {@link #getTopLevelDeclaredTypes()}
+	 */
+	JavaType<?> getGoverningType();
+	
+	/**
+	 * 
+	 * @return types in the toplevel of source code in the declared order.
+	 */
+	List<? extends JavaType<?>> getTopLevelDeclaredTypes();
+	
+	
+	/**
+	 * write out the source code operated.
+	 * 
+	 * @return
+	 */
+	String toString();
+
+}

--- a/api/src/main/java/org/jboss/forge/roaster/spi/JavaParser.java
+++ b/api/src/main/java/org/jboss/forge/roaster/spi/JavaParser.java
@@ -7,9 +7,11 @@
 package org.jboss.forge.roaster.spi;
 
 import java.io.InputStream;
+import java.util.List;
 
 import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -33,5 +35,15 @@ public interface JavaParser
     * @return {@link JavaType}, {@code null} if the data format is not recognized by this {@link JavaParser}.
     */
    JavaType<?> parse(final InputStream data);
+   
+   
+   /**
+    * Read the given {@link InputStream} and parse the data into a source code file data type representation.
+    * 
+    * @param encoding encoding used when the data is a string
+    * @param data to parse
+    * @return {@link JavaSourceUnit}, {@code null} if the data format is not recognized by this {@link JavaParser}.
+    */
+   JavaSourceUnit parse(final String encoding, final InputStream data);
 
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -475,9 +475,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       JavaType<?> enclosingType = this;
       while (enclosingType != enclosingType.getEnclosingType())
       {
-         enclosingType = getEnclosingType();
-         result = enclosingType.getEnclosingType().getName() + "." + result;
          enclosingType = enclosingType.getEnclosingType();
+         result = enclosingType.getName() + "." + result;
+//         enclosingType = enclosingType.getEnclosingType();
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))
@@ -499,9 +499,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       JavaType<?> enclosingType = this;
       while (enclosingType != enclosingType.getEnclosingType())
       {
-         enclosingType = getEnclosingType();
-         result = enclosingType.getEnclosingType().getName() + "$" + result;
          enclosingType = enclosingType.getEnclosingType();
+         result = enclosingType.getName() + "$" + result;
+//         enclosingType = enclosingType.getEnclosingType();
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -630,6 +630,12 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    @Override
    public String toString()
    {
+      return Formatter.format(toUnformattedString());
+   }
+   
+   @Override
+   public String toUnformattedString()
+   {
       Document document = new Document(this.document.get());
 
       try
@@ -646,8 +652,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
          throw new ParserException("Could not modify source: " + unit.toString(), e);
       }
 
-      return Formatter.format(document.get());
+      return document.get();
    }
+
 
    @Override
    public Object getInternal()

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
@@ -922,4 +922,17 @@ class EnumConstantBodyImpl implements EnumConstantSource.Body
    {
       return (BodyDeclaration) getBody().bodyDeclarations().get(0);
    }
+
+   /**
+    * Why? Is this a JavaType?
+    */
+   @Override
+   public String toUnformattedString() 
+   {
+	   //do something unknown...
+	   return toString(); 
+   }
+
+   
+   
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -590,19 +590,25 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    @Override
    public String toString()
    {
-      Document document = new Document(this.document.get());
+      return Formatter.format(toUnformattedString());
+   }
+   
 
-      try
-      {
-         TextEdit edit = unit.rewrite(document, null);
-         edit.apply(document);
-      }
-      catch (Exception e)
-      {
-         throw new ParserException("Could not modify source: " + unit.toString(), e);
-      }
+   @Override
+   public String toUnformattedString() {
+	   Document document = new Document(this.document.get());
 
-      return Formatter.format(document.get());
+	   try
+	   {
+		   TextEdit edit = unit.rewrite(document, null);
+		   edit.apply(document);
+	   }
+	   catch (Exception e)
+	   {
+		   throw new ParserException("Could not modify source: " + unit.toString(), e);
+	   }
+
+	   return document.get();
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/spi/JavaParserImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/spi/JavaParserImpl.java
@@ -91,6 +91,11 @@ public class JavaParserImpl implements JavaParser
 				public String toString(){
 					return getGoverningType().toString();
 				}
+
+				@Override
+				public String toUnformattedString() {
+					return getGoverningType().toUnformattedString();
+				}
 			};
 	         
 	         

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaClassMultiDeclsInAFile.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaClassMultiDeclsInAFile.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.test.roaster.model;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
+import org.jboss.forge.roaster.spi.Streams;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class JavaClassMultiDeclsInAFile {
+	static String classNameMain = "MockMultipleClassDeclesInAFile";
+	static String classNameSub = "MockAcompanyingClass";
+	
+	@Test
+	public void testParseOnly() throws UnsupportedEncodingException{
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		Streams.write(
+				JavaClassMultiDeclsInAFile.class.getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java")
+				, b );
+		
+		JavaSourceUnit unit = 
+				Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+		
+		org.junit.Assert.
+		assertEquals( new String( b.toByteArray(), "UTF-8" ), unit.toString() );
+	}
+	
+	
+	@Test
+	public void testParsedResult() throws UnsupportedEncodingException{
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		Streams.write(
+				JavaClassMultiDeclsInAFile.class.getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java")
+				, b );
+		
+		JavaSourceUnit unit = 
+				Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+		
+		Assert.assertEquals( classNameMain, unit.getTopLevelDeclaredTypes().get(0).getName() );
+		Assert.assertEquals( classNameSub, unit.getTopLevelDeclaredTypes().get(1).getName() );
+		
+	}
+	
+	
+	@Test
+	public void testOperationOnPackage() throws UnsupportedEncodingException{
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		Streams.write(
+				JavaClassMultiDeclsInAFile.class.getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java")
+				, b );
+		
+		JavaSourceUnit unit = 
+				Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+		
+		JavaClassSource j = Roaster.tryCast(unit.getGoverningType(), JavaClassSource.class);
+		j.setPackage("tesstto.operated");
+		
+		String newsource = unit.toString();
+		
+		Assert.assertTrue(newsource.contains("package tesstto.operated;"));
+//		Assert.assertTrue(newsource.contains("package tesstto.operted;")); // test of test
+		Assert.assertTrue(newsource.contains(classNameMain));
+		Assert.assertTrue(newsource.contains(classNameSub));
+		
+//		System.out.println( newsource ); seems ok
+	}
+
+	@Test
+	public void testOperationOnAccompaningClass() throws UnsupportedEncodingException{
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		Streams.write(
+				JavaClassMultiDeclsInAFile.class.getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java")
+				, b );
+		
+		JavaSourceUnit unit = 
+				Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+		
+		JavaClassSource j = Roaster.tryCast( unit.getTopLevelDeclaredTypes().get(1), JavaClassSource.class);
+		j.addField("private static int tesueito;");
+		
+		
+		String newsource = unit.toString();
+		
+		Assert.assertTrue(newsource.contains(classNameMain));
+		Assert.assertTrue(newsource.contains(classNameSub));
+		Assert.assertTrue(newsource.contains("private static int tesueito;"));
+//		Assert.assertTrue(newsource.contains("private static int tesueitoX;")); //test of test
+		Assert.assertTrue(
+				newsource.indexOf(classNameMain) < 
+				newsource.indexOf(classNameSub));
+		Assert.assertTrue(
+				newsource.indexOf(classNameSub) < 
+				newsource.indexOf("private static int tesueito;"));
+		
+//		System.out.println( newsource ); seems ok
+		
+	}
+	
+	@Test
+	public void testBothAnnotationAdd() throws UnsupportedEncodingException{
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		Streams.write(
+				JavaClassMultiDeclsInAFile.class.getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java")
+				, b );
+		
+		JavaSourceUnit unit = 
+				Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+		
+		
+		Class x[] = new Class[]{ Deprecated.class, SuppressWarnings.class };
+		
+		for ( int i = 0; i < 2; i ++ ){
+			JavaClassSource j = Roaster.tryCast( unit.getTopLevelDeclaredTypes().get(i), JavaClassSource.class );
+			j.addAnnotation(x[i]);
+		}
+		
+		
+		String newsource = unit.toString();
+		
+		Assert.assertTrue(newsource.contains(classNameMain));
+		Assert.assertTrue(newsource.contains(classNameSub));
+		Assert.assertTrue(newsource.contains(x[0].getSimpleName() ));
+		Assert.assertTrue(newsource.contains(x[1].getSimpleName() ));
+		
+		Assert.assertTrue(
+				newsource.indexOf(x[0].getSimpleName()) < 
+				newsource.indexOf(classNameMain));
+		Assert.assertTrue(
+				newsource.indexOf(classNameMain) < 
+				newsource.indexOf(x[1].getSimpleName()));
+//		Assert.assertTrue( //test of test
+//				newsource.indexOf(classNameMain) > 
+//				newsource.indexOf(x[1].getSimpleName()));
+		Assert.assertTrue(
+				newsource.indexOf(x[1].getSimpleName()) < 
+				newsource.indexOf(classNameSub));
+
+		
+//		System.out.println( newsource ); seems ok
+		
+	}
+
+}

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/NestedClassTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/NestedClassTest.java
@@ -47,6 +47,7 @@ public class NestedClassTest
       List<JavaSource<?>> nestedClasses = javaClass.getNestedTypes();
       JavaClassSource inner1 = (JavaClassSource) nestedClasses.get(0);
       JavaClassSource inner2 = (JavaClassSource) nestedClasses.get(1);
+      JavaClassSource inner3 = (JavaClassSource) inner1.getNestedTypes().get(0);
       Assert.assertEquals(javaClass, inner1.getEnclosingType());
       Assert.assertEquals("org.example.OuterClass.InnerClass1", inner1.getCanonicalName());
       Assert.assertEquals("org.example.OuterClass$InnerClass1", inner1.getQualifiedName());
@@ -56,6 +57,9 @@ public class NestedClassTest
       Assert.assertEquals("org.example.OuterClass$InnerClass2", inner2.getQualifiedName());
       Assert.assertEquals("InnerClass2", inner2.getName());
       Assert.assertEquals(2, nestedClasses.size());
+      
+      Assert.assertEquals("org.example.OuterClass$InnerClass1$InnerClass3", inner3.getQualifiedName());
+      Assert.assertEquals("org.example.OuterClass.InnerClass1.InnerClass3", inner3.getCanonicalName());
    }
 
    @Test

--- a/impl/src/test/resources/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java
+++ b/impl/src/test/resources/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.grammar.java;
+
+import java.net.URL;
+
+public class MockMultipleClassDeclesInAFile {
+}
+
+class MockAcompanyingClass {
+}


### PR DESCRIPTION
ROASTER-72: Adds a new API and data structure to parse the multiple declarations of
classes in a java file.
An instance of the 'JavaSourceUnit' represents a java source file which
contains multiple declarations of type.
An API named Roaster.parse2(String encoding, InputStream data) is
tentatively created to extract the JavaSourceUnit result.
Some tests for the new function are created at
'JavaClassMultiDeclsInAFile.java'.