### PR TITLE
ROASTER-73 : fix and test for the bug in AbstractJavaSource#getQualifiedName() and

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -475,9 +475,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       JavaType<?> enclosingType = this;
       while (enclosingType != enclosingType.getEnclosingType())
       {
-         enclosingType = getEnclosingType();
-         result = enclosingType.getEnclosingType().getName() + "." + result;
          enclosingType = enclosingType.getEnclosingType();
+         result = enclosingType.getName() + "." + result;
+//         enclosingType = enclosingType.getEnclosingType();
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))
@@ -499,9 +499,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       JavaType<?> enclosingType = this;
       while (enclosingType != enclosingType.getEnclosingType())
       {
-         enclosingType = getEnclosingType();
-         result = enclosingType.getEnclosingType().getName() + "$" + result;
          enclosingType = enclosingType.getEnclosingType();
+         result = enclosingType.getName() + "$" + result;
+//         enclosingType = enclosingType.getEnclosingType();
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/NestedClassTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/NestedClassTest.java
@@ -47,6 +47,7 @@ public class NestedClassTest
       List<JavaSource<?>> nestedClasses = javaClass.getNestedTypes();
       JavaClassSource inner1 = (JavaClassSource) nestedClasses.get(0);
       JavaClassSource inner2 = (JavaClassSource) nestedClasses.get(1);
+      JavaClassSource inner3 = (JavaClassSource) inner1.getNestedTypes().get(0);
       Assert.assertEquals(javaClass, inner1.getEnclosingType());
       Assert.assertEquals("org.example.OuterClass.InnerClass1", inner1.getCanonicalName());
       Assert.assertEquals("org.example.OuterClass$InnerClass1", inner1.getQualifiedName());
@@ -56,6 +57,9 @@ public class NestedClassTest
       Assert.assertEquals("org.example.OuterClass$InnerClass2", inner2.getQualifiedName());
       Assert.assertEquals("InnerClass2", inner2.getName());
       Assert.assertEquals(2, nestedClasses.size());
+      
+      Assert.assertEquals("org.example.OuterClass$InnerClass1$InnerClass3", inner3.getQualifiedName());
+      Assert.assertEquals("org.example.OuterClass.InnerClass1.InnerClass3", inner3.getCanonicalName());
    }
 
    @Test


### PR DESCRIPTION
#getCanonicalName().