### PR TITLE
ROASTER-72 : Adds a new API and data structure to parse the multiple declarations of

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/Roaster.java
+++ b/api/src/main/java/org/jboss/forge/roaster/Roaster.java
@@ -20,6 +20,7 @@ import java.util.ServiceLoader;
 
 import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
 import org.jboss.forge.roaster.spi.FormatterProvider;
 import org.jboss.forge.roaster.spi.JavaParser;
 
@@ -191,6 +192,43 @@ public final class Roaster
          }
       }
       throw new ParserException("Cannot find JavaParserProvider capable of parsing the requested data");
+   }
+
+   /**
+    * Read the given {@link InputStream} and parse its data into a source code file structure which contains a List of
+    * new {@link JavaType} instances of the given type. The caller is responsible for closing the stream.
+    */
+   @Deprecated
+   public static JavaSourceUnit parse2(String encoding_if_its_string, final InputStream data)
+   {
+      for (JavaParser parser : getParsers())
+      {
+         final JavaSourceUnit sources = parser.parse(encoding_if_its_string, data);
+
+         if (sources != null)
+            return sources;
+      }
+      throw new ParserException("Cannot find JavaParserProvider capable of parsing the requested data");
+   }
+
+   /**
+    * Try to cast the 'source' object into the type of 'type'.
+    *
+    * @param source
+    * @param type
+    * @return
+    * @throws ParserException when the cast cannot be done for some reasons.
+    */
+   public static <T extends JavaType<?>> T tryCast(final JavaType<?> source, final Class<T> type)
+   {
+      if (type.isInstance(source))
+      {
+         @SuppressWarnings("unchecked")
+         final T result = (T) source;
+         return result;
+      }
+      throw new ParserException(
+               "the [" + source.getClass().getSimpleName() + "] cannot be casted into [" + type.getSimpleName() + "]");
    }
 
    /**

--- a/api/src/main/java/org/jboss/forge/roaster/model/source/JavaSourceUnit.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/JavaSourceUnit.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.roaster.model.source;
+
+import java.util.List;
+
+import org.jboss.forge.roaster.model.JavaType;
+
+public interface JavaSourceUnit
+{
+
+   /**
+    * A type in the source file governs the declaration environment such as 'package' and 'import' information.
+    * 
+    * @return basically the first element of {@link #getTopLevelDeclaredTypes()}
+    */
+   JavaType<?> getGoverningType();
+
+   /**
+    * 
+    * @return types in the toplevel of source code in the declared order.
+    */
+   List<? extends JavaType<?>> getTopLevelDeclaredTypes();
+
+   /**
+    * write out the source code operated.
+    * 
+    * @return
+    */
+   String toString();
+
+//   String toUnformattedString();
+
+}

--- a/api/src/main/java/org/jboss/forge/roaster/spi/JavaParser.java
+++ b/api/src/main/java/org/jboss/forge/roaster/spi/JavaParser.java
@@ -7,9 +7,11 @@
 package org.jboss.forge.roaster.spi;
 
 import java.io.InputStream;
+import java.util.List;
 
 import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -33,5 +35,14 @@ public interface JavaParser
     * @return {@link JavaType}, {@code null} if the data format is not recognized by this {@link JavaParser}.
     */
    JavaType<?> parse(final InputStream data);
+
+   /**
+    * Read the given {@link InputStream} and parse the data into a source code file data type representation.
+    * 
+    * @param encoding encoding used when the data is a string
+    * @param data to parse
+    * @return {@link JavaSourceUnit}, {@code null} if the data format is not recognized by this {@link JavaParser}.
+    */
+   JavaSourceUnit parse(final String encoding, final InputStream data);
 
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/spi/JavaParserImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/spi/JavaParserImpl.java
@@ -9,6 +9,8 @@ package org.jboss.forge.roaster.spi;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +41,7 @@ import org.jboss.forge.roaster.model.source.JavaEnumSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaPackageInfoSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -63,6 +66,91 @@ public class JavaParserImpl implements JavaParser
       {
          Streams.closeQuietly(data);
       }
+   }
+
+   @Override
+   public JavaSourceUnit parse(String encoding, InputStream data)
+   {
+      try
+      {
+         char[] source = Util.getInputStreamAsCharArray(data, data.available(), encoding);
+         final List<? extends JavaType<?>> X = parseGen2(new String(source));
+
+         if (X.size() == 0)
+            return null;
+
+         return new JavaSourceUnit()
+         {
+            @Override
+            public List<? extends JavaType<?>> getTopLevelDeclaredTypes()
+            {
+               return X;
+            }
+
+            @Override
+            public JavaType<?> getGoverningType()
+            {
+               return X.get(0);
+            }
+
+            public String toString()
+            {
+               return getGoverningType().toString();
+            }
+
+//            @Override
+//            public String toUnformattedString()
+//            {
+//               return getGoverningType().toUnformattedString();
+//            }
+         };
+
+      }
+      catch (IOException e)
+      {
+         return null;
+      }
+      finally
+      {
+         Streams.closeQuietly(data);
+      }
+   }
+
+   private List<? extends JavaType<?>> parseGen2(String data)
+   {
+      Document document = new Document(data);
+      ASTParser parser = ASTParser.newParser(AST.JLS8);
+
+      parser.setSource(document.get().toCharArray());
+      Map options = JavaCore.getOptions();
+      options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_8);
+      options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
+      parser.setCompilerOptions(options);
+
+      parser.setResolveBindings(true);
+      parser.setKind(ASTParser.K_COMPILATION_UNIT);
+      CompilationUnit unit = (CompilationUnit) parser.createAST(null);
+      unit.recordModifications();
+
+      TypeDeclarationFinderVisitor visitor = new TypeDeclarationFinderVisitor();
+      unit.accept(visitor);
+
+      List<AbstractTypeDeclaration> declarations = visitor.getTypeDeclarations();
+      if (!declarations.isEmpty())
+      {
+         List<JavaType<?>> decls = new ArrayList<JavaType<?>>();
+         for (AbstractTypeDeclaration declaration : declarations)
+         {
+            if (declaration.isPackageMemberTypeDeclaration()) // this 'if' must be here
+               decls.add(getJavaSource(null, document, unit, declaration));
+         }
+         return decls;
+      }
+      else if (visitor.getPackageDeclaration() != null)
+      {
+         return Arrays.asList(getJavaSource(null, document, unit, visitor.getPackageDeclaration()));
+      }
+      throw new ParserException("Could not find type declaration in Java source - is this actually code?");
    }
 
    @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaClassMultiDeclsInAFile.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaClassMultiDeclsInAFile.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.test.roaster.model;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaSourceUnit;
+import org.jboss.forge.roaster.spi.Streams;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JavaClassMultiDeclsInAFile
+{
+   static String classNameMain = "MockMultipleClassDeclesInAFile";
+   static String classNameSub = "MockAcompanyingClass";
+
+   @Test
+   public void testParseOnly() throws UnsupportedEncodingException
+   {
+      ByteArrayOutputStream b = new ByteArrayOutputStream();
+      Streams.write(
+               JavaClassMultiDeclsInAFile.class
+                        .getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java"),
+               b);
+
+      JavaSourceUnit unit = Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+
+      org.junit.Assert.assertEquals(new String(b.toByteArray(), "UTF-8"), unit.toString());
+   }
+
+   @Test
+   public void testParsedResult() throws UnsupportedEncodingException
+   {
+      ByteArrayOutputStream b = new ByteArrayOutputStream();
+      Streams.write(
+               JavaClassMultiDeclsInAFile.class
+                        .getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java"),
+               b);
+
+      JavaSourceUnit unit = Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+
+      Assert.assertEquals(classNameMain, unit.getTopLevelDeclaredTypes().get(0).getName());
+      Assert.assertEquals(classNameSub, unit.getTopLevelDeclaredTypes().get(1).getName());
+
+   }
+
+   @Test
+   public void testOperationOnPackage() throws UnsupportedEncodingException
+   {
+      ByteArrayOutputStream b = new ByteArrayOutputStream();
+      Streams.write(
+               JavaClassMultiDeclsInAFile.class
+                        .getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java"),
+               b);
+
+      JavaSourceUnit unit = Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+
+      JavaClassSource j = Roaster.tryCast(unit.getGoverningType(), JavaClassSource.class);
+      j.setPackage("tesstto.operated");
+
+      String newsource = unit.toString();
+
+      Assert.assertTrue(newsource.contains("package tesstto.operated;"));
+      // Assert.assertTrue(newsource.contains("package tesstto.operted;")); // test of test
+      Assert.assertTrue(newsource.contains(classNameMain));
+      Assert.assertTrue(newsource.contains(classNameSub));
+
+      // System.out.println( newsource ); seems ok
+   }
+
+   @Test
+   public void testOperationOnAccompaningClass() throws UnsupportedEncodingException
+   {
+      ByteArrayOutputStream b = new ByteArrayOutputStream();
+      Streams.write(
+               JavaClassMultiDeclsInAFile.class
+                        .getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java"),
+               b);
+
+      JavaSourceUnit unit = Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+
+      JavaClassSource j = Roaster.tryCast(unit.getTopLevelDeclaredTypes().get(1), JavaClassSource.class);
+      j.addField("private static int tesueito;");
+
+      String newsource = unit.toString();
+
+      Assert.assertTrue(newsource.contains(classNameMain));
+      Assert.assertTrue(newsource.contains(classNameSub));
+      Assert.assertTrue(newsource.contains("private static int tesueito;"));
+      // Assert.assertTrue(newsource.contains("private static int tesueitoX;")); //test of test
+      Assert.assertTrue(
+               newsource.indexOf(classNameMain) < newsource.indexOf(classNameSub));
+      Assert.assertTrue(
+               newsource.indexOf(classNameSub) < newsource.indexOf("private static int tesueito;"));
+
+      // System.out.println( newsource ); seems ok
+
+   }
+
+   @Test
+   public void testBothAnnotationAdd() throws UnsupportedEncodingException
+   {
+      ByteArrayOutputStream b = new ByteArrayOutputStream();
+      Streams.write(
+               JavaClassMultiDeclsInAFile.class
+                        .getResourceAsStream("/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java"),
+               b);
+
+      JavaSourceUnit unit = Roaster.parse2("UTF-8", new ByteArrayInputStream(b.toByteArray()));
+
+      Class x[] = new Class[] { Deprecated.class, SuppressWarnings.class };
+
+      for (int i = 0; i < 2; i++)
+      {
+         JavaClassSource j = Roaster.tryCast(unit.getTopLevelDeclaredTypes().get(i), JavaClassSource.class);
+         j.addAnnotation(x[i]);
+      }
+
+      String newsource = unit.toString();
+
+      Assert.assertTrue(newsource.contains(classNameMain));
+      Assert.assertTrue(newsource.contains(classNameSub));
+      Assert.assertTrue(newsource.contains(x[0].getSimpleName()));
+      Assert.assertTrue(newsource.contains(x[1].getSimpleName()));
+
+      Assert.assertTrue(
+               newsource.indexOf(x[0].getSimpleName()) < newsource.indexOf(classNameMain));
+      Assert.assertTrue(
+               newsource.indexOf(classNameMain) < newsource.indexOf(x[1].getSimpleName()));
+      // Assert.assertTrue( //test of test
+      // newsource.indexOf(classNameMain) >
+      // newsource.indexOf(x[1].getSimpleName()));
+      Assert.assertTrue(
+               newsource.indexOf(x[1].getSimpleName()) < newsource.indexOf(classNameSub));
+
+      // System.out.println( newsource ); seems ok
+
+   }
+
+}

--- a/impl/src/test/resources/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java
+++ b/impl/src/test/resources/org/jboss/forge/grammar/java/MockMultipleClassDeclesInAFile.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.grammar.java;
+
+import java.net.URL;
+
+public class MockMultipleClassDeclesInAFile {
+	static class Inner1 {
+	}
+}
+
+class MockAcompanyingClass {
+	public static class Inner2 {
+	}
+}


### PR DESCRIPTION
classes in a java file.
An instance of the 'JavaSourceUnit' represents a java source file which
contains multiple declarations of type.
A API named Roaster.parse2(String encoding, InputStream data) is
tentatively created to extract the JavaSourceUnit result.
Some tests for the new function are created at
'JavaClassMultiDeclsInAFile.java'.

Although there is a bug where an inner class declaration is moved into
the top level at the initial version, the bug is removed. 
The test corresponding to the bug is also added.
Furthermore the code is formatted by the Forge style.