### PR TITLE
Fixes getMethod that retrieves the first method with no parameters

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSourceMemberHolder.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSourceMemberHolder.java
@@ -263,7 +263,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
             List<ParameterSource<O>> localParams = local.getParameters();
             if (paramTypes != null)
             {
-               if (localParams.isEmpty() || (localParams.size() == paramTypes.length))
+               if (localParams.size() == paramTypes.length)
                {
                   boolean matches = true;
                   for (int i = 0; i < localParams.size(); i++)

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaClassMethodTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaClassMethodTest.java
@@ -41,6 +41,43 @@ public class JavaClassMethodTest
    }
 
    @Test
+   public void testGetMethodByString() throws Exception 
+   {
+      javaClass.addMethod("public void random() { }");
+      javaClass.addMethod("public void random(String randomString) { }");
+    
+      MethodSource<JavaClassSource> randomMethod = javaClass.getMethod("random");
+      
+      List<ParameterSource<JavaClassSource>> randomMethodParameters = randomMethod.getParameters();
+      assertEquals(0, randomMethodParameters.size());
+      assertFalse(javaClass.hasMethodSignature(method.getName()));
+      
+      MethodSource<JavaClassSource> randomMethodString = javaClass.getMethod("random", "String");
+      List<ParameterSource<JavaClassSource>> randomMethodStringParameters = randomMethodString.getParameters();
+      assertEquals(1, randomMethodStringParameters.size());
+      assertEquals("String", randomMethodStringParameters.get(0).getType().getName());
+      assertFalse(javaClass.hasMethodSignature(method.getName()));
+   }
+   
+   @Test
+   public void testGetMethodByClass() throws Exception 
+   {
+      javaClass.addMethod("public void random() { }");
+      javaClass.addMethod("public void random(String randomString) { }");
+    
+      MethodSource<JavaClassSource> randomMethod = javaClass.getMethod("random");
+      List<ParameterSource<JavaClassSource>> randomMethodParameters = randomMethod.getParameters();
+      assertEquals(0, randomMethodParameters.size());
+      assertFalse(javaClass.hasMethodSignature(method.getName()));
+      
+      MethodSource<JavaClassSource> randomMethodString = javaClass.getMethod("random", String.class);
+      List<ParameterSource<JavaClassSource>> randomMethodStringParameters = randomMethodString.getParameters();
+      assertEquals(1, randomMethodStringParameters.size());
+      assertEquals("String", randomMethodStringParameters.get(0).getType().getName());
+      assertFalse(javaClass.hasMethodSignature(method.getName()));
+   }
+   
+   @Test
    public void testSetName() throws Exception
    {
       assertEquals("rewriteURL", method.getName());


### PR DESCRIPTION
When you try to get a method with parameters, you instead get the first method with no parameters if it exists.