### PR TITLE
fix stack overflow in ABstractJavaSource.hashCode()

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -672,7 +672,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       int result = 1;
       result = prime * result + ((body == null) ? 0 : body.hashCode());
       result = prime * result + ((document == null) ? 0 : document.hashCode());
-      result = prime * result + ((enclosingType == null) ? 0 : enclosingType.hashCode());
+      result = prime * result + ((enclosingType == null || enclosingType == this) ? 0 : enclosingType.hashCode());
       result = prime * result + ((unit == null) ? 0 : unit.hashCode());
       return result;
    }

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/common/InterfacedTestBase.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/common/InterfacedTestBase.java
@@ -101,4 +101,10 @@ public abstract class InterfacedTestBase<T extends JavaSource<T> & InterfaceCapa
       assertFalse(this.source.hasInterface(Serializable.class));
       assertEquals(2, this.source.getInterfaces().size());
    }
+
+   @Test
+   public void testHashCode() throws Exception
+   {
+      this.source.hashCode();
+   }
 }


### PR DESCRIPTION
this.enclosingType == this for JavaInterfaceImpl at least, which leads to a stack overflow in hashcode()