### PR TITLE
ROASTER-91: implementInterface doesn't work for JavaInterfaceSource

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -37,6 +37,7 @@ import org.jboss.forge.roaster.model.source.AnnotationSource;
 import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaDocSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 import org.jboss.forge.roaster.model.source.ParameterSource;
@@ -340,25 +341,33 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    @Override
    public boolean isAbstract()
    {
-      return modifiers.hasModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
+      return (parent instanceof JavaInterfaceSource) ? true
+               : modifiers.hasModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
    }
 
    @Override
    public MethodSource<O> setAbstract(final boolean abstrct)
    {
-      if (abstrct)
+      if (!(parent instanceof JavaInterfaceSource))
       {
-         modifiers.addModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
-         // Abstract methods do not specify a body
-         setBody((String) null);
+         if (abstrct)
+         {
+            modifiers.addModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
+            // Abstract methods do not specify a body
+            setBody((String) null);
+         }
+         else
+         {
+            modifiers.removeModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
+            if (getBody() == null)
+            {
+               setBody("");
+            }
+         }
       }
       else
       {
-         modifiers.removeModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
-         if (getBody() == null)
-         {
-            setBody("");
-         }
+         throw new IllegalArgumentException("Methods interface doesn't need abstract modifier");
       }
       return this;
    }


### PR DESCRIPTION
Change isAbstract & setAbstract in order to manage JavaInterfaceSource
behavior.