### PR TITLE
ROASTER-91 : implementInterface doesn't work for JavaInterfaceSource

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -37,6 +37,7 @@ import org.jboss.forge.roaster.model.source.AnnotationSource;
 import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaDocSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 import org.jboss.forge.roaster.model.source.ParameterSource;
@@ -340,24 +341,28 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    @Override
    public boolean isAbstract()
    {
-      return modifiers.hasModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
+      return (parent instanceof JavaInterfaceSource) ? true
+               : modifiers.hasModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
    }
 
    @Override
    public MethodSource<O> setAbstract(final boolean abstrct)
    {
-      if (abstrct)
+      if (!(parent instanceof JavaInterfaceSource))
       {
-         modifiers.addModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
-         // Abstract methods do not specify a body
-         setBody((String) null);
-      }
-      else
-      {
-         modifiers.removeModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
-         if (getBody() == null)
+         if (abstrct)
          {
-            setBody("");
+            modifiers.addModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
+            // Abstract methods do not specify a body
+            setBody((String) null);
+         }
+         else
+         {
+            modifiers.removeModifier(method, ModifierKeyword.ABSTRACT_KEYWORD);
+            if (getBody() == null)
+            {
+               setBody("");
+            }
          }
       }
       return this;

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodImplementationTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodImplementationTest.java
@@ -35,8 +35,9 @@ public class MethodImplementationTest
    {
       JavaClassSource source = Roaster.create(JavaClassSource.class);
       JavaInterfaceSource interfaceSource = Roaster.create(JavaInterfaceSource.class).setName("Bar").setPackage("test");
-      interfaceSource.addMethod().setAbstract(true).setName("doSomething").setReturnTypeVoid();
+      interfaceSource.addMethod().setName("doSomething").setReturnTypeVoid();
       source.implementInterface(interfaceSource);
+      Assert.assertThat(interfaceSource.getMethod("doSomething").isAbstract(), is(true));
       Assert.assertThat(source.getMethods().size(), is(1));
       Assert.assertNotNull(source.getMethod("doSomething"));
       Assert.assertThat(source.getMethod("doSomething").isAbstract(), is(false));
@@ -60,8 +61,9 @@ public class MethodImplementationTest
    {
       JavaEnumSource source = Roaster.create(JavaEnumSource.class);
       JavaInterfaceSource interfaceSource = Roaster.create(JavaInterfaceSource.class).setName("Bar").setPackage("test");
-      interfaceSource.addMethod().setAbstract(true).setName("doSomething").setReturnTypeVoid();
+      interfaceSource.addMethod().setName("doSomething").setReturnTypeVoid();
       source.implementInterface(interfaceSource);
+      Assert.assertThat(interfaceSource.getMethod("doSomething").isAbstract(), is(true));
       Assert.assertThat(source.getMethods().size(), is(1));
       Assert.assertNotNull(source.getMethod("doSomething"));
       Assert.assertThat(source.getMethod("doSomething").isAbstract(), is(false));


### PR DESCRIPTION
Change MethodImpl#isAbstract() & MethodImpl#setAbstract() to handle
interface special behavior. A method interface is abstract by default,
so it doesn't need modifier.
JUnit test updated.