### PR TITLE
ROASTER-92 : implementInterface shouldn't copy annotation

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/source/AnnotationTargetSource.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/AnnotationTargetSource.java
@@ -51,4 +51,9 @@ public interface AnnotationTargetSource<O extends JavaSource<O>, T> extends Anno
     * Remove an annotation instance from this {@link T}.
     */
    T removeAnnotation(Annotation<O> annotation);
+   
+   /**
+    * Remove all annotations instance from this {@link T}.
+    */
+   void removeAnnotations();
 }

--- a/api/src/main/java/org/jboss/forge/roaster/model/source/AnnotationTargetSource.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/AnnotationTargetSource.java
@@ -55,5 +55,5 @@ public interface AnnotationTargetSource<O extends JavaSource<O>, T> extends Anno
    /**
     * Remove all annotations instance from this {@link T}.
     */
-   void removeAnnotations();
+   void removeAllAnnotations();
 }

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Methods.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Methods.java
@@ -42,19 +42,19 @@ public class Methods
          {
             MethodSource<?> newMethod = target.addMethod(method);
             implementMethod(newMethod);
-            removeAnnotations(newMethod);
+            removeAllAnnotations(newMethod);
             methods.add(newMethod);
          }
       }
       return methods;
    }
 
-   public static void removeAnnotations(final MethodSource<?> source)
+   public static void removeAllAnnotations(final MethodSource<?> source)
    {
-      source.removeAnnotations();
+      source.removeAllAnnotations();
       for (ParameterSource<?> parameterSource : source.getParameters())
       {
-         parameterSource.removeAnnotations();
+         parameterSource.removeAllAnnotations();
       }
    }
 
@@ -78,7 +78,7 @@ public class Methods
          {
             MethodSource<?> newMethod = target.addMethod(m);
             implementMethod(newMethod);
-            removeAnnotations(newMethod);
+            removeAllAnnotations(newMethod);
             methods.add(newMethod);
          }
       }

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Methods.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Methods.java
@@ -15,6 +15,7 @@ import org.jboss.forge.roaster.model.Method;
 import org.jboss.forge.roaster.model.MethodHolder;
 import org.jboss.forge.roaster.model.source.MethodHolderSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
+import org.jboss.forge.roaster.model.source.ParameterSource;
 
 /**
  * Utility methods for {@link MethodSource} objects
@@ -41,10 +42,20 @@ public class Methods
          {
             MethodSource<?> newMethod = target.addMethod(method);
             implementMethod(newMethod);
+            removeAnnotations(newMethod);
             methods.add(newMethod);
          }
       }
       return methods;
+   }
+
+   public static void removeAnnotations(final MethodSource<?> source)
+   {
+      source.removeAnnotations();
+      for (ParameterSource<?> parameterSource : source.getParameters())
+      {
+         parameterSource.removeAnnotations();
+      }
    }
 
    /**
@@ -67,6 +78,7 @@ public class Methods
          {
             MethodSource<?> newMethod = target.addMethod(m);
             implementMethod(newMethod);
+            removeAnnotations(newMethod);
             methods.add(newMethod);
          }
       }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/ast/AnnotationAccessor.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/ast/AnnotationAccessor.java
@@ -149,6 +149,29 @@ public class AnnotationAccessor<O extends JavaSource<O>, T>
       return target;
    }
 
+   public void removeAnnotations(final ASTNode body)
+   {
+      removeAnnotation(getModifiers(body));
+
+   }
+
+   public void removeAnnotations(final SingleVariableDeclaration variableDeclaration)
+   {
+      removeAnnotation(variableDeclaration.modifiers());
+   }
+
+   private void removeAnnotation(final List<?> modifiers)
+   {
+      List<?> modifiersCopy = new ArrayList<Object>(modifiers);
+      for (Object object : modifiersCopy)
+      {
+         if(object instanceof org.eclipse.jdt.core.dom.Annotation)
+         {
+            modifiers.remove(object);
+         }
+      }
+   }
+
    public <E extends AnnotationTargetSource<O, T>> boolean hasAnnotation(final E target, final ASTNode body,
             final String type)
    {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/ast/AnnotationAccessor.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/ast/AnnotationAccessor.java
@@ -9,6 +9,7 @@ package org.jboss.forge.roaster.model.ast;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -149,25 +150,26 @@ public class AnnotationAccessor<O extends JavaSource<O>, T>
       return target;
    }
 
-   public void removeAnnotations(final ASTNode body)
+   public void removeAllAnnotations(final ASTNode body)
    {
-      removeAnnotation(getModifiers(body));
+      removeAllAnnotations(getModifiers(body));
 
    }
 
-   public void removeAnnotations(final SingleVariableDeclaration variableDeclaration)
+   public void removeAllAnnotations(final SingleVariableDeclaration variableDeclaration)
    {
-      removeAnnotation(variableDeclaration.modifiers());
+      removeAllAnnotations(variableDeclaration.modifiers());
    }
 
-   private void removeAnnotation(final List<?> modifiers)
+   private void removeAllAnnotations(final List<?> modifiers)
    {
-      List<?> modifiersCopy = new ArrayList<Object>(modifiers);
-      for (Object object : modifiersCopy)
+      Iterator<?> iterator = modifiers.iterator();
+      while (iterator.hasNext())
       {
-         if(object instanceof org.eclipse.jdt.core.dom.Annotation)
+         Object object = iterator.next();
+         if (object instanceof org.eclipse.jdt.core.dom.Annotation)
          {
-            modifiers.remove(object);
+            iterator.remove();
          }
       }
    }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -131,9 +131,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    }
    
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-     annotations.removeAnnotations(getBodyDeclaration());
+     annotations.removeAllAnnotations(getBodyDeclaration());
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -129,6 +129,12 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       return (O) annotations.removeAnnotation(this, getBodyDeclaration(), annotation);
    }
+   
+   @Override
+   public void removeAnnotations()
+   {
+     annotations.removeAnnotations(getBodyDeclaration());
+   }
 
    @Override
    public AnnotationSource<O> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationElementImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationElementImpl.java
@@ -397,6 +397,12 @@ public class AnnotationElementImpl implements AnnotationElementSource
    {
       return annotations.removeAnnotation(this, member, annotation);
    }
+   
+   @Override
+   public void removeAnnotations()
+   {
+      annotations.removeAnnotations(member);
+   }
 
    @Override
    public String toString()

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationElementImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationElementImpl.java
@@ -399,9 +399,9 @@ public class AnnotationElementImpl implements AnnotationElementSource
    }
    
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-      annotations.removeAnnotations(member);
+      annotations.removeAllAnnotations(member);
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
@@ -405,7 +405,7 @@ class EnumConstantBodyImpl implements EnumConstantSource.Body
    }
 
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
       // could pass through to enumConstant, but would require then pretending its Annotation was ours
       // which should cause no problem at the moment, but could theoretically do so in the future

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
@@ -405,6 +405,13 @@ class EnumConstantBodyImpl implements EnumConstantSource.Body
    }
 
    @Override
+   public void removeAnnotations()
+   {
+      // could pass through to enumConstant, but would require then pretending its Annotation was ours
+      // which should cause no problem at the moment, but could theoretically do so in the future
+   }
+
+   @Override
    public Object getInternal()
    {
       return javaEnum.getInternal();

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantImpl.java
@@ -184,6 +184,12 @@ public class EnumConstantImpl implements EnumConstantSource
    }
 
    @Override
+   public void removeAnnotations()
+   {
+      annotations.removeAnnotations(enumConstant);
+   }
+
+   @Override
    public AnnotationSource<JavaEnumSource> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
    {
       return annotations.getAnnotation(this, enumConstant, type);

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantImpl.java
@@ -184,9 +184,9 @@ public class EnumConstantImpl implements EnumConstantSource
    }
 
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-      annotations.removeAnnotations(enumConstant);
+      annotations.removeAllAnnotations(enumConstant);
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
@@ -171,9 +171,9 @@ public class FieldImpl<O extends JavaSource<O>> implements FieldSource<O>
    }
 
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-      annotations.removeAnnotations(field);
+      annotations.removeAllAnnotations(field);
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
@@ -171,6 +171,12 @@ public class FieldImpl<O extends JavaSource<O>> implements FieldSource<O>
    }
 
    @Override
+   public void removeAnnotations()
+   {
+      annotations.removeAnnotations(field);
+   }
+
+   @Override
    public String toString()
    {
       return field.toString();

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -117,9 +117,9 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    }
 
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-      annotations.removeAnnotations(getPackageDeclaration());
+      annotations.removeAllAnnotations(getPackageDeclaration());
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -117,6 +117,12 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    }
 
    @Override
+   public void removeAnnotations()
+   {
+      annotations.removeAnnotations(getPackageDeclaration());
+   }
+
+   @Override
    public AnnotationSource<JavaPackageInfoSource> getAnnotation(
             final Class<? extends java.lang.annotation.Annotation> type)
    {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -208,9 +208,9 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    }
    
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-      annotations.removeAnnotations(method);
+      annotations.removeAllAnnotations(method);
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -206,6 +206,12 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    {
       return annotations.removeAnnotation(this, method, annotation);
    }
+   
+   @Override
+   public void removeAnnotations()
+   {
+      annotations.removeAnnotations(method);
+   }
 
    @Override
    public AnnotationSource<O> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/ParameterImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/ParameterImpl.java
@@ -117,6 +117,12 @@ public class ParameterImpl<O extends JavaSource<O>> implements ParameterSource<O
    {
       return annotations.removeAnnotation(this, param, annotation);
    }
+   
+   @Override
+   public void removeAnnotations()
+   {
+     annotations.removeAnnotations(param);
+   }
 
    @Override
    public boolean isFinal()

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/ParameterImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/ParameterImpl.java
@@ -119,9 +119,9 @@ public class ParameterImpl<O extends JavaSource<O>> implements ParameterSource<O
    }
    
    @Override
-   public void removeAnnotations()
+   public void removeAllAnnotations()
    {
-     annotations.removeAnnotations(param);
+     annotations.removeAllAnnotations(param);
    }
 
    @Override

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodImplementationTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodImplementationTest.java
@@ -10,15 +10,19 @@ package org.jboss.forge.test.roaster.model;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 import java.util.Enumeration;
 
 import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.AnnotationSource;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.JavaEnumSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 import org.jboss.forge.roaster.model.util.Methods;
+import org.jboss.forge.test.roaster.model.common.MockAnnotatedInterface;
+import org.jboss.forge.test.roaster.model.common.MockAnnotation;
 import org.jboss.forge.test.roaster.model.common.MockInterface;
 import org.jboss.forge.test.roaster.model.common.MockSuperType;
 import org.junit.Assert;
@@ -40,6 +44,21 @@ public class MethodImplementationTest
       Assert.assertThat(source.getMethods().size(), is(1));
       Assert.assertNotNull(source.getMethod("doSomething"));
       Assert.assertThat(source.getMethod("doSomething").isAbstract(), is(false));
+   }
+
+   @Test
+   public void testJavaClassImplementInterfaceWithAnnotation() throws Exception
+   {
+      JavaClassSource source = Roaster.create(JavaClassSource.class);
+      JavaInterfaceSource interfaceSource = Roaster.create(JavaInterfaceSource.class).setName("Bar").setPackage("test");
+      MethodSource<JavaInterfaceSource> interfaceMethod = interfaceSource.addMethod().setAbstract(true).setName("doSomething");
+      interfaceMethod.addAnnotation(MockAnnotation.class);
+      interfaceMethod.addParameter(String.class, "parameter").addAnnotation(MockAnnotation.class);
+      source.implementInterface(interfaceSource);
+      Assert.assertThat(source.getMethod("doSomething", String.class).getAnnotation(MockAnnotation.class), nullValue());
+      Assert.assertThat(
+               source.getMethod("doSomething", String.class).getParameters().get(0).getAnnotation(MockAnnotation.class),
+               nullValue());
    }
 
    @Test
@@ -65,6 +84,23 @@ public class MethodImplementationTest
       Assert.assertThat(source.getMethods().size(), is(1));
       Assert.assertNotNull(source.getMethod("doSomething"));
       Assert.assertThat(source.getMethod("doSomething").isAbstract(), is(false));
+   }
+
+   @Test
+   public void testJavaEnumImplementInterfaceWithAnnotation() throws Exception
+   {
+      JavaEnumSource source = Roaster.create(JavaEnumSource.class);
+      JavaInterfaceSource interfaceSource = Roaster.create(JavaInterfaceSource.class).setName("Bar").setPackage("test");
+      MethodSource<JavaInterfaceSource> interfaceMethod = interfaceSource.addMethod().setAbstract(true).setName("doSomething");
+      interfaceMethod.addAnnotation(MockAnnotation.class);
+      interfaceMethod.addParameter(String.class, "parameter").addAnnotation(MockAnnotation.class);
+      source.implementInterface(interfaceSource);
+      MethodSource<JavaEnumSource> method = source.getMethod("doSomething", String.class);
+      AnnotationSource<JavaEnumSource> annotation = method.getAnnotation(MockAnnotation.class);
+      Assert.assertThat(annotation, nullValue());
+      Assert.assertThat(
+               method.getParameters().get(0).getAnnotation(MockAnnotation.class),
+               nullValue());
    }
 
    @Test
@@ -140,6 +176,19 @@ public class MethodImplementationTest
       Assert.assertThat(source.getMethod("lookup", String.class, boolean.class), notNullValue());
       Assert.assertThat(source.getMethod("lookup", int.class, boolean.class), notNullValue());
       Assert.assertThat(source.getMethod("lookup", int.class, int.class, boolean.class), notNullValue());
+   }
+
+   @Test
+   public void testJavaClassImplementInterfaceWithReflectedMethodsWithAnnotation() throws Exception
+   {
+      JavaClassSource source = Roaster.create(JavaClassSource.class);
+      source.implementInterface(MockAnnotatedInterface.class);
+      Assert.assertThat(source.getMethod("lookup", String.class, boolean.class).getAnnotation(MockAnnotation.class),
+               nullValue());
+      Assert.assertThat(source.getMethod("lookup", String.class, boolean.class).getParameters().get(0)
+               .getAnnotation(MockAnnotation.class), nullValue());
+      Assert.assertThat(source.getMethod("lookup", String.class, boolean.class).getParameters().get(1)
+               .getAnnotation(MockAnnotation.class), nullValue());
    }
 
 }

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/common/MockAnnotatedInterface.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/common/MockAnnotatedInterface.java
@@ -1,0 +1,15 @@
+
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.test.roaster.model.common;
+
+public interface MockAnnotatedInterface
+{
+   @MockAnnotation
+   MockSuperType lookup(@MockAnnotation String name, @MockAnnotation boolean create);
+}


### PR DESCRIPTION
I add removeAnnotations method on all annotations holder.
Then a call this method on methodSource and all parameter of implemented
methods.
If you implements an iterface, you'll get all inherited methods without annotaitons.