### PR TITLE
ROASTER-91 : Add JavaInterfaceMethodImpl class

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaInterfaceImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaInterfaceImpl.java
@@ -6,17 +6,25 @@
  */
 package org.jboss.forge.roaster.model.impl;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jface.text.Document;
+import org.jboss.forge.roaster.model.Method;
+import org.jboss.forge.roaster.model.ast.MethodFinderVisitor;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class JavaInterfaceImpl extends AbstractGenericCapableJavaSource<JavaInterfaceSource>implements
+public class JavaInterfaceImpl extends AbstractGenericCapableJavaSource<JavaInterfaceSource> implements
          JavaInterfaceSource
 {
 
@@ -31,5 +39,58 @@ public class JavaInterfaceImpl extends AbstractGenericCapableJavaSource<JavaInte
    {
       return this;
    }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public MethodSource<JavaInterfaceSource> addMethod()
+   {
+      MethodSource<JavaInterfaceSource> m = new JavaInterfaceMethodImpl(this);
+      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      return m;
+   }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public MethodSource<JavaInterfaceSource> addMethod(final String method)
+   {
+      MethodSource<JavaInterfaceSource> m = new JavaInterfaceMethodImpl(this, method);
+      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      return m;
+   }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public MethodSource<JavaInterfaceSource> addMethod(java.lang.reflect.Method method)
+   {
+      MethodSource<JavaInterfaceSource> m = new JavaInterfaceMethodImpl(this, method);
+      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      return m;
+   }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public MethodSource<JavaInterfaceSource> addMethod(Method<?, ?> method)
+   {
+      MethodSource<JavaInterfaceSource> m = new JavaInterfaceMethodImpl(this, method.toString());
+      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      return m;
+   }
+   
+   @Override
+   public List<MethodSource<JavaInterfaceSource>> getMethods()
+   {
+      List<MethodSource<JavaInterfaceSource>> result = new ArrayList<MethodSource<JavaInterfaceSource>>();
+
+      MethodFinderVisitor methodFinderVisitor = new MethodFinderVisitor();
+      body.accept(methodFinderVisitor);
+
+      List<MethodDeclaration> methods = methodFinderVisitor.getMethods();
+      for (MethodDeclaration methodDeclaration : methods)
+      {
+         result.add(new JavaInterfaceMethodImpl(this, methodDeclaration));
+      }
+      return Collections.unmodifiableList(result);
+   }
+   
 
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaInterfaceMethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaInterfaceMethodImpl.java
@@ -1,0 +1,189 @@
+package org.jboss.forge.roaster.model.impl;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+import org.jboss.forge.roaster.model.util.Methods;
+
+public class JavaInterfaceMethodImpl extends MethodImpl<JavaInterfaceSource>
+{
+
+   public JavaInterfaceMethodImpl(JavaInterfaceSource parent)
+   {
+      super(parent);
+   }
+
+   public JavaInterfaceMethodImpl(JavaInterfaceSource parent, Method reflectMethod)
+   {
+       this(parent);
+       // Set method return type
+       if (reflectMethod.getReturnType() == Void.TYPE)
+       {
+       setReturnTypeVoid();
+       }
+       else
+       {
+       setReturnType(reflectMethod.getReturnType());
+       }
+       // Set method name
+       setName(reflectMethod.getName());
+       // Set method parameters
+       Class<?>[] paramTypes = reflectMethod.getParameterTypes();
+       String[] paramNames = Methods.generateParameterNames(paramTypes);
+       for (int i = 0; i < paramTypes.length; i++)
+       {
+       addParameter(paramTypes[i], paramNames[i]);
+       }
+   }
+
+   public JavaInterfaceMethodImpl(JavaInterfaceSource parent, Object internal)
+   {
+      super(parent, internal);
+   }
+
+   public JavaInterfaceMethodImpl(JavaInterfaceSource parent, String method)
+   {
+      super(parent, method);
+   }
+
+   @Override
+   public boolean isAbstract()
+   {
+      if (isDefault() || isStatic())
+      {
+         return false;
+      }
+      else
+      {
+         return true;
+      }
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setAbstract(boolean abstrct)
+   {
+      if (abstrct)
+      {
+         return super.setAbstract(abstrct);
+      }
+      else
+      {
+         throw new IllegalStateException("Method interface should be 'abstract'");
+      }
+   }
+
+   @Override
+   public boolean isPublic()
+   {
+      return true;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setBody(String body)
+   {
+      if (body == null)
+      {
+         return this;
+      }
+      if (isDefault())
+      {
+         return super.setBody(body);
+      }
+      else if (isStatic())
+      {
+         return super.setBody(body);
+      }
+      else
+      {
+         throw new IllegalStateException("To set body, a method interface should be 'default' or 'static'");
+      }
+   }
+
+   @Override
+   public boolean isConstructor()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setConstructor(boolean constructor)
+   {
+      throw new UnsupportedOperationException("An interface couldn't have a constructor");
+   }
+
+   @Override
+   public boolean isFinal()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setFinal(boolean finl)
+   {
+      throw new UnsupportedOperationException("A method interface couldn't be final");
+   }
+
+   @Override
+   public boolean isNative()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setNative(boolean value)
+   {
+      throw new UnsupportedOperationException("A method interface couldn't be native");
+   }
+
+   @Override
+   public boolean isPrivate()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setPrivate()
+   {
+      throw new UnsupportedOperationException("A method interface couldn't be private");
+   }
+
+   @Override
+   public boolean isProtected()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setProtected()
+   {
+      throw new UnsupportedOperationException("A method interface couldn't be protected");
+   }
+
+   @Override
+   public boolean isPackagePrivate()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setPackagePrivate()
+   {
+      throw new UnsupportedOperationException("A method interface couldn't be package private");
+   }
+
+   @Override
+   public boolean isSynchronized()
+   {
+      return false;
+   }
+
+   @Override
+   public MethodSource<JavaInterfaceSource> setSynchronized(boolean value)
+   {
+      throw new UnsupportedOperationException("A method interface couldn't be synchronized");
+   }
+
+}

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaInterfaceMethodTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/JavaInterfaceMethodTest.java
@@ -1,0 +1,151 @@
+package org.jboss.forge.test.roaster.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+import org.jboss.forge.roaster.model.source.ParameterSource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class JavaInterfaceMethodTest
+{
+
+   private InputStream stream;
+   private JavaInterfaceSource javaInterface;
+   private MethodSource<JavaInterfaceSource> method;
+
+   @Rule
+   public final ExpectedException exception = ExpectedException.none();
+
+   @Before
+   public void reset()
+   {
+      stream = JavaInterfaceMethodTest.class.getResourceAsStream("/org/jboss/forge/grammar/java/MockInterface.java");
+      javaInterface = Roaster.parse(JavaInterfaceSource.class, stream);
+      javaInterface.addMethod("URL rewriteURL(String pattern, String replacement);");
+      method = javaInterface.getMethods().get(javaInterface.getMethods().size() - 1);
+   }
+
+   @Test
+   public void testGetMethodByString()
+   {
+      javaInterface.addMethod("public void random() { }");
+      javaInterface.addMethod("public void random(String randomString) { }");
+
+      MethodSource<JavaInterfaceSource> randomMethod = javaInterface.getMethod("random");
+
+      List<ParameterSource<JavaInterfaceSource>> randomMethodParameters = randomMethod.getParameters();
+      assertEquals(0, randomMethodParameters.size());
+      assertFalse(javaInterface.hasMethodSignature(method.getName()));
+
+      MethodSource<JavaInterfaceSource> randomMethodString = javaInterface.getMethod("random", "String");
+      List<ParameterSource<JavaInterfaceSource>> randomMethodStringParameters = randomMethodString.getParameters();
+      assertEquals(1, randomMethodStringParameters.size());
+      assertEquals("String", randomMethodStringParameters.get(0).getType().getName());
+      assertFalse(javaInterface.hasMethodSignature(method.getName()));
+   }
+
+   @Test
+   public void testGetMethodByClass() throws Exception
+   {
+      javaInterface.addMethod("public void random() { }");
+      javaInterface.addMethod("public void random(String randomString) { }");
+
+      MethodSource<JavaInterfaceSource> randomMethod = javaInterface.getMethod("random");
+      List<ParameterSource<JavaInterfaceSource>> randomMethodParameters = randomMethod.getParameters();
+      assertEquals(0, randomMethodParameters.size());
+      assertFalse(javaInterface.hasMethodSignature(method.getName()));
+
+      MethodSource<JavaInterfaceSource> randomMethodString = javaInterface.getMethod("random", String.class);
+      List<ParameterSource<JavaInterfaceSource>> randomMethodStringParameters = randomMethodString.getParameters();
+      assertEquals(1, randomMethodStringParameters.size());
+      assertEquals("String", randomMethodStringParameters.get(0).getType().getName());
+      assertFalse(javaInterface.hasMethodSignature(method.getName()));
+   }
+
+   @Test
+   public void testSetAbstract()
+   {
+      assertTrue(method.isAbstract());
+      method.setAbstract(true);
+      Assert.assertEquals(((MethodDeclaration) method.getInternal()).getModifiers(), Modifier.ABSTRACT);
+      exception.expect(IllegalStateException.class);
+      method.setAbstract(false);
+   }
+
+   @Test
+   public void testSetConstructor()
+   {
+      assertFalse(method.isConstructor());
+      exception.expect(UnsupportedOperationException.class);
+      method.setConstructor(true);
+   }
+
+   @Test
+   public void testSetPublic()
+   {
+      assertTrue(method.isPublic());
+      method.setPublic();
+      Assert.assertEquals(((MethodDeclaration) method.getInternal()).getModifiers(), Modifier.PUBLIC);
+
+   }
+
+   @Test
+   public void testSetPrivate()
+   {
+      assertFalse(method.isPrivate());
+      exception.expect(UnsupportedOperationException.class);
+      method.setPrivate();
+   }
+
+   @Test
+   public void testSetProtected()
+   {
+      assertFalse(method.isProtected());
+      exception.expect(UnsupportedOperationException.class);
+      method.setProtected();
+   }
+
+   @Test
+   public void testSetPackagePrivate()
+   {
+      assertFalse(method.isPackagePrivate());
+      exception.expect(UnsupportedOperationException.class);
+      method.setPackagePrivate();
+   }
+
+   @Test
+   public void testSetDefault()
+   {
+      method.setDefault(true);
+      method.setBody("Object o;");
+      Assert.assertEquals(method.getBody(), "Object o;");
+   }
+
+   @Test
+   public void testSetStatic()
+   {
+      method.setStatic(true);
+      method.setBody("Object o;");
+      Assert.assertEquals(method.getBody(), "Object o;");
+   }
+
+   @Test
+   public void testSetBody()
+   {
+      exception.expect(IllegalStateException.class);
+      method.setBody("Object o;");
+   }
+}

--- a/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodModifierTest.java
+++ b/impl/src/test/java/org/jboss/forge/test/roaster/model/MethodModifierTest.java
@@ -48,7 +48,7 @@ public class MethodModifierTest
       Assert.assertEquals(body, method.getBody());
    }
 
-   @Test
+   @Test(expected = IllegalStateException.class)
    public void testDefaultModifier() throws Exception
    {
       MethodSource<JavaInterfaceSource> method = Roaster.create(JavaInterfaceSource.class).addMethod(
@@ -60,8 +60,6 @@ public class MethodModifierTest
       Assert.assertThat(method.getBody(), equalTo(""));
       String body = "int a=2;";
       method.setDefault(false).setBody(body);
-      Assert.assertFalse(method.isDefault());
-      Assert.assertEquals(body, method.getBody());
    }
 
    @Test


### PR DESCRIPTION
Add JavaInterfaceMethodImpl in order to manage special method interface behavior.
JavainterfaceImpl change too, it now use JavaInterfaceMethodImpl instead of generic MethodImpl