### PR TITLE
Staging/string literals should not be duplicated

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Refactory.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Refactory.java
@@ -25,7 +25,7 @@ public class Refactory
 {
    private static final String RETURN_FALSE = " return false;";
 
-/**
+    /**
     * Generates a getXXX and setXXX method for the supplied field
     *
     * @param clazz

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Refactory.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Refactory.java
@@ -23,7 +23,9 @@ import org.jboss.forge.roaster.model.source.MethodSource;
  */
 public class Refactory
 {
-   /**
+   private static final String RETURN_FALSE = " return false;";
+
+/**
     * Generates a getXXX and setXXX method for the supplied field
     *
     * @param clazz
@@ -154,7 +156,7 @@ public class Refactory
                fieldEqualityChecks.append("if (Float.floatToIntBits(").append(fieldName)
                         .append(") != Float.floatToIntBits(other.").append(fieldName)
                         .append(")) { ");
-               fieldEqualityChecks.append(" return false;");
+               fieldEqualityChecks.append(RETURN_FALSE);
                fieldEqualityChecks.append("} ");
 
             }
@@ -163,14 +165,14 @@ public class Refactory
                fieldEqualityChecks.append("if (Double.doubleToLongBits(").append(fieldName)
                         .append(") != Double.doubleToLongBits(other.").append(fieldName)
                         .append(")) { ");
-               fieldEqualityChecks.append(" return false;");
+               fieldEqualityChecks.append(RETURN_FALSE);
                fieldEqualityChecks.append("} ");
             }
             else
             {
                fieldEqualityChecks.append("if (").append(fieldName).append(" != other.").append(fieldName)
                         .append(") { ");
-               fieldEqualityChecks.append(" return false;");
+               fieldEqualityChecks.append(RETURN_FALSE);
                fieldEqualityChecks.append("} ");
             }
          }

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -27,7 +27,7 @@ public class Types
 {
    private static final String BOOLEAN = "boolean";
 
-// [B=byte,
+   // [B=byte,
    // [F=float,
    // [C=char,
    // [D=double,

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -25,7 +25,9 @@ import org.jboss.forge.roaster.model.Type;
  */
 public class Types
 {
-   // [B=byte,
+   private static final String BOOLEAN = "boolean";
+
+// [B=byte,
    // [F=float,
    // [C=char,
    // [D=double,
@@ -482,7 +484,7 @@ public class Types
             result = "short";
             break;
          case 'Z':
-            result = "boolean";
+            result = BOOLEAN;
             break;
          case 'L':
             result = matcher.group(2);
@@ -500,7 +502,7 @@ public class Types
 
    public static boolean isPrimitive(final String result)
    {
-      return Arrays.asList("byte", "short", "int", "long", "float", "double", "boolean", "char").contains(result);
+      return Arrays.asList("byte", "short", "int", "long", "float", "double", BOOLEAN, "char").contains(result);
    }
 
    /**
@@ -596,7 +598,7 @@ public class Types
       final String result;
       if (Types.isPrimitive(type))
       {
-         if ("boolean".equals(type) || Boolean.TYPE.getName().equals(type))
+         if (BOOLEAN.equals(type) || Boolean.TYPE.getName().equals(type))
          {
             result = "false";
          }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationImpl.java
@@ -43,10 +43,8 @@ import org.jboss.forge.roaster.model.util.Strings;
 public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSource<O>
 {
    private static final String NULL_VALUE_NOT_ACCEPTED = "null value not accepted";
-
-private static final String NULL_ARRAY_NOT_ACCEPTED = "null array not accepted";
-
-private static final String NULL_NOT_ACCEPTED = "null not accepted";
+   private static final String NULL_ARRAY_NOT_ACCEPTED = "null array not accepted";
+   private static final String NULL_NOT_ACCEPTED = "null not accepted";
 
 private class Nested extends AnnotationImpl<O, T>
    {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationImpl.java
@@ -46,7 +46,7 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    private static final String NULL_ARRAY_NOT_ACCEPTED = "null array not accepted";
    private static final String NULL_NOT_ACCEPTED = "null not accepted";
 
-private class Nested extends AnnotationImpl<O, T>
+   private class Nested extends AnnotationImpl<O, T>
    {
       Nested(AnnotationImpl<O, T> owner)
       {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AnnotationImpl.java
@@ -42,7 +42,13 @@ import org.jboss.forge.roaster.model.util.Strings;
  */
 public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSource<O>
 {
-   private class Nested extends AnnotationImpl<O, T>
+   private static final String NULL_VALUE_NOT_ACCEPTED = "null value not accepted";
+
+private static final String NULL_ARRAY_NOT_ACCEPTED = "null array not accepted";
+
+private static final String NULL_NOT_ACCEPTED = "null not accepted";
+
+private class Nested extends AnnotationImpl<O, T>
    {
       Nested(AnnotationImpl<O, T> owner)
       {
@@ -304,7 +310,7 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    @Override
    public AnnotationSource<O> setLiteralValue(final String value)
    {
-      Assert.notNull(value, "null not accepted");
+      Assert.notNull(value, NULL_NOT_ACCEPTED);
 
       if (isMarker())
       {
@@ -335,7 +341,7 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    @SuppressWarnings("unchecked")
    public AnnotationSource<O> setLiteralValue(final String name, final String value)
    {
-      Assert.notNull(value, "null not accepted");
+      Assert.notNull(value, NULL_NOT_ACCEPTED);
 
       if (!isNormal() && !DEFAULT_VALUE.equals(name))
       {
@@ -440,13 +446,13 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    @Override
    public AnnotationSource<O> setEnumArrayValue(String name, final Enum<?>... values)
    {
-      Assert.notNull(values, "null array not accepted");
+      Assert.notNull(values, NULL_ARRAY_NOT_ACCEPTED);
 
       final List<String> literals = new ArrayList<String>();
 
       for (Enum<?> value : values)
       {
-         Assert.notNull(value, "null value not accepted");
+         Assert.notNull(value, NULL_VALUE_NOT_ACCEPTED);
          getOrigin().addImport(value.getDeclaringClass());
          literals.add(value.getDeclaringClass().getSimpleName() + "." + value.name());
       }
@@ -1029,7 +1035,7 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    @Override
    public AnnotationSource<O> setClassValue(String name, Class<?> value)
    {
-      Assert.notNull(value, "null not accepted");
+      Assert.notNull(value, NULL_NOT_ACCEPTED);
 
       if (!value.isPrimitive())
       {
@@ -1059,13 +1065,13 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    @Override
    public AnnotationSource<O> setStringArrayValue(String name, String[] values)
    {
-      Assert.notNull(values, "null array not accepted");
+      Assert.notNull(values, NULL_ARRAY_NOT_ACCEPTED);
 
       final List<String> literals = new ArrayList<String>();
 
       for (String value : values)
       {
-         Assert.notNull(value, "null value not accepted");
+         Assert.notNull(value, NULL_VALUE_NOT_ACCEPTED);
          literals.add(Strings.enquote(value));
       }
       return setLiteralValue(name,
@@ -1075,13 +1081,13 @@ public class AnnotationImpl<O extends JavaSource<O>, T> implements AnnotationSou
    @Override
    public AnnotationSource<O> setClassArrayValue(String name, Class<?>... values)
    {
-      Assert.notNull(values, "null array not accepted");
+      Assert.notNull(values, NULL_ARRAY_NOT_ACCEPTED);
 
       final List<String> literals = new ArrayList<String>();
 
       for (Class<?> value : values)
       {
-         Assert.notNull(value, "null value not accepted");
+         Assert.notNull(value, NULL_VALUE_NOT_ACCEPTED);
 
          if (!value.isPrimitive())
          {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
@@ -53,7 +53,8 @@ import org.jboss.forge.roaster.spi.JavaParserImpl;
 @SuppressWarnings("unchecked")
 class EnumConstantBodyImpl implements EnumConstantSource.Body
 {
-   private final EnumConstantSource enumConstant;
+   private static final String ENUM_CONSTANTS_BODY_ALLOW_ONLY_CLASSES_TO_BE_ADDED = "Enum constants body allow only classes to be added ";
+private final EnumConstantSource enumConstant;
    private final JavaEnumSource javaEnum;
 
    EnumConstantBodyImpl(EnumConstantSource enumConstant)
@@ -853,7 +854,7 @@ class EnumConstantBodyImpl implements EnumConstantSource.Body
    {
       if (type != JavaClassSource.class)
       {
-         throw new IllegalArgumentException("Enum constants body allow only classes to be added ");
+         throw new IllegalArgumentException(ENUM_CONSTANTS_BODY_ALLOW_ONLY_CLASSES_TO_BE_ADDED);
       }
       JavaSource<?> nestedType = Roaster.create(type);
       return (NESTED_TYPE) addNestedType(nestedType);
@@ -865,7 +866,7 @@ class EnumConstantBodyImpl implements EnumConstantSource.Body
       JavaType<?> source = Roaster.parse(declaration);
       if (!source.isClass())
       {
-         throw new IllegalArgumentException("Enum constants body allow only classes to be added ");
+         throw new IllegalArgumentException(ENUM_CONSTANTS_BODY_ALLOW_ONLY_CLASSES_TO_BE_ADDED);
       }
       JavaSource<?> nestedType = Roaster.parse(JavaSource.class, declaration);
       return (NESTED_TYPE) addNestedType(nestedType);
@@ -888,7 +889,7 @@ class EnumConstantBodyImpl implements EnumConstantSource.Body
    {
       if (!type.isClass())
       {
-         throw new IllegalArgumentException("Enum constants body allow only classes to be added ");
+         throw new IllegalArgumentException(ENUM_CONSTANTS_BODY_ALLOW_ONLY_CLASSES_TO_BE_ADDED);
       }
       if (type instanceof AbstractJavaSource)
       {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/EnumConstantBodyImpl.java
@@ -54,7 +54,7 @@ import org.jboss.forge.roaster.spi.JavaParserImpl;
 class EnumConstantBodyImpl implements EnumConstantSource.Body
 {
    private static final String ENUM_CONSTANTS_BODY_ALLOW_ONLY_CLASSES_TO_BE_ADDED = "Enum constants body allow only classes to be added ";
-private final EnumConstantSource enumConstant;
+   private final EnumConstantSource enumConstant;
    private final JavaEnumSource javaEnum;
 
    EnumConstantBodyImpl(EnumConstantSource enumConstant)

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaDocImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaDocImpl.java
@@ -30,7 +30,8 @@ import org.jboss.forge.roaster.model.util.Assert;
 @SuppressWarnings("unchecked")
 public class JavaDocImpl<O> implements JavaDocSource<O>
 {
-   private final O origin;
+   private static final String TAG_NAME_CANNOT_BE_NULL = "Tag name cannot be null";
+private final O origin;
    private final Javadoc javadoc;
 
    public JavaDocImpl(O origin, Javadoc javadoc)
@@ -125,7 +126,7 @@ public class JavaDocImpl<O> implements JavaDocSource<O>
    @Override
    public List<JavaDocTag> getTags(String tagName)
    {
-      Assert.notNull(tagName, "Tag name cannot be null");
+      Assert.notNull(tagName, TAG_NAME_CANNOT_BE_NULL);
       List<JavaDocTag> tags = new ArrayList<JavaDocTag>();
       List<TagElement> tagElements = javadoc.tags();
       for (TagElement tagElement : tagElements)
@@ -174,7 +175,7 @@ public class JavaDocImpl<O> implements JavaDocSource<O>
    @Override
    public JavaDocSource<O> addTagValue(String tagName, String tagValue)
    {
-      Assert.notNull(tagName, "Tag name cannot be null");
+      Assert.notNull(tagName, TAG_NAME_CANNOT_BE_NULL);
       TagElement tagElement = javadoc.getAST().newTagElement();
       TextElement textElement = javadoc.getAST().newTextElement();
 
@@ -197,7 +198,7 @@ public class JavaDocImpl<O> implements JavaDocSource<O>
    @Override
    public JavaDocSource<O> removeTags(String tagName)
    {
-      Assert.notNull(tagName, "Tag name cannot be null");
+      Assert.notNull(tagName, TAG_NAME_CANNOT_BE_NULL);
       List<TagElement> tags = javadoc.tags();
       Iterator<TagElement> iterator = tags.iterator();
       while (iterator.hasNext())

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaDocImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaDocImpl.java
@@ -31,7 +31,7 @@ import org.jboss.forge.roaster.model.util.Assert;
 public class JavaDocImpl<O> implements JavaDocSource<O>
 {
    private static final String TAG_NAME_CANNOT_BE_NULL = "Tag name cannot be null";
-private final O origin;
+   private final O origin;
    private final Javadoc javadoc;
 
    public JavaDocImpl(O origin, Javadoc javadoc)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava