### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/DesignPatterns.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/DesignPatterns.java
@@ -136,7 +136,7 @@ public class DesignPatterns
                         .getQualifiedName(), param.getName());
             }
             sb.append(");");
-            for (String o : ((List<String>) method.getThrownExceptions()))
+            for (String o : (List<String>) method.getThrownExceptions())
             {
                decoratorMethod.addThrows(o);
             }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -561,7 +561,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    @Override
    public boolean isPackagePrivate()
    {
-      return (!isPublic() && !isPrivate() && !isProtected());
+      return !isPublic() && !isPrivate() && !isProtected();
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
@@ -221,7 +221,7 @@ public class FieldImpl<O extends JavaSource<O>> implements FieldSource<O>
    @Override
    public boolean isPackagePrivate()
    {
-      return (!isPublic() && !isPrivate() && !isProtected());
+      return !isPublic() && !isPrivate() && !isProtected();
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaEnumImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaEnumImpl.java
@@ -37,7 +37,7 @@ public class JavaEnumImpl extends AbstractJavaSourceMemberHolder<JavaEnumSource>
    {
       List<EnumConstantSource> result = new ArrayList<EnumConstantSource>();
 
-      for (Object o : (((EnumDeclaration) getBodyDeclaration()).enumConstants()))
+      for (Object o : ((EnumDeclaration) getBodyDeclaration()).enumConstants())
       {
          EnumConstantDeclaration constant = (EnumConstantDeclaration) o;
          result.add(new EnumConstantImpl(this, constant));

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -523,7 +523,7 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    @Override
    public boolean isPackagePrivate()
    {
-      return (!isPublic() && !isPrivate() && !isProtected());
+      return !isPublic() && !isPrivate() && !isProtected();
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -139,8 +139,8 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    public String toSignature()
    {
       StringBuilder signature = new StringBuilder();
-      signature.append((Visibility.PACKAGE_PRIVATE.equals(this.getVisibility().scope()) ? "" : this.getVisibility()
-               .scope()));
+      signature.append(Visibility.PACKAGE_PRIVATE.equals(this.getVisibility().scope()) ? "" : this.getVisibility()
+               .scope());
       signature.append(" ");
       signature.append(this.getName()).append("(");
       List<ParameterSource<O>> parameters = this.getParameters();
@@ -519,7 +519,7 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    @Override
    public boolean isPackagePrivate()
    {
-      return (!isPublic() && !isPrivate() && !isProtected());
+      return !isPublic() && !isPrivate() && !isProtected();
    }
 
    @Override
@@ -747,7 +747,7 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
       {
          if (Strings.areEqual(name, typeParameter.getName().getIdentifier()))
          {
-            return (new TypeVariableImpl<O>(parent, typeParameter));
+            return new TypeVariableImpl<O>(parent, typeParameter);
          }
       }
       return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava