### PR TITLE
Local variables should not shadow class fields

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -478,11 +478,11 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       String result = getName();
 
-      JavaType<?> enclosingType = this;
-      while (enclosingType != enclosingType.getEnclosingType())
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
       {
-         enclosingType = enclosingType.getEnclosingType();
-         result = enclosingType.getName() + "." + result;
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
+         result = enclosingTypeLocal.getName() + "." + result;
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))
@@ -501,11 +501,11 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       String result = getName();
 
-      JavaType<?> enclosingType = this;
-      while (enclosingType != enclosingType.getEnclosingType())
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
       {
-         enclosingType = enclosingType.getEnclosingType();
-         result = enclosingType.getName() + "$" + result;
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
+         result = enclosingTypeLocal.getName() + "$" + result;
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))
@@ -640,7 +640,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    @Override
    public String toUnformattedString()
    {
-      Document document = new Document(this.document.get());
+      Document documentLocal = new Document(this.document.get());
 
       try
       {
@@ -648,15 +648,15 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
          Map options = JavaCore.getOptions();
          options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
          options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
-         TextEdit edit = unit.rewrite(document, options);
-         edit.apply(document);
+         TextEdit edit = unit.rewrite(documentLocal, options);
+         edit.apply(documentLocal);
       }
       catch (Exception e)
       {
          throw new ParserException("Could not modify source: " + unit.toString(), e);
       }
 
-      return document.get();
+      return documentLocal.get();
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -443,12 +443,12 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    {
       String result = getName();
 
-      JavaType<?> enclosingType = this;
-      while (enclosingType != enclosingType.getEnclosingType())
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
       {
-         enclosingType = getEnclosingType();
-         result = enclosingType.getEnclosingType().getName() + "." + result;
-         enclosingType = enclosingType.getEnclosingType();
+         enclosingTypeLocal = getEnclosingType();
+         result = enclosingTypeLocal.getEnclosingType().getName() + "." + result;
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))
@@ -462,12 +462,12 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    {
       String result = getName();
 
-      JavaType<?> enclosingType = this;
-      while (enclosingType != enclosingType.getEnclosingType())
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
       {
-         enclosingType = getEnclosingType();
-         result = enclosingType.getEnclosingType().getName() + "$" + result;
-         enclosingType = enclosingType.getEnclosingType();
+         enclosingTypeLocal = getEnclosingType();
+         result = enclosingTypeLocal.getEnclosingType().getName() + "$" + result;
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
       }
 
       if (!Strings.isNullOrEmpty(getPackage()))
@@ -482,10 +482,10 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    @Override
    public String getPackage()
    {
-      PackageDeclaration pkg = unit.getPackage();
-      if (pkg != null)
+      PackageDeclaration pkgLocal = unit.getPackage();
+      if (pkgLocal != null)
       {
-         return pkg.getName().getFullyQualifiedName();
+         return pkgLocal.getName().getFullyQualifiedName();
       }
       else
       {
@@ -602,19 +602,19 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    @Override
    public String toUnformattedString()
    {
-      Document document = new Document(this.document.get());
+      Document documentLocal = new Document(this.document.get());
 
       try
       {
-         TextEdit edit = unit.rewrite(document, null);
-         edit.apply(document);
+         TextEdit edit = unit.rewrite(documentLocal, null);
+         edit.apply(documentLocal);
       }
       catch (Exception e)
       {
          throw new ParserException("Could not modify source: " + unit.toString(), e);
       }
 
-      return document.get();
+      return documentLocal.get();
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/TypeImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/TypeImpl.java
@@ -83,17 +83,17 @@ public class TypeImpl<O extends JavaType<O>> implements Type<O>
    @SuppressWarnings("unchecked")
    public List<Type<O>> getTypeArguments()
    {
-      org.eclipse.jdt.core.dom.Type type = this.type;
+      org.eclipse.jdt.core.dom.Type typeLocal = this.type;
 
-      if (type.isArrayType())
+      if (typeLocal.isArrayType())
       {
-         type = ((ArrayType) type).getElementType();
+         typeLocal = ((ArrayType) typeLocal).getElementType();
       }
 
-      if (type instanceof ParameterizedType)
+      if (typeLocal instanceof ParameterizedType)
       {
          List<Type<O>> result = new ArrayList<Type<O>>();
-         List<org.eclipse.jdt.core.dom.Type> arguments = ((ParameterizedType) type).typeArguments();
+         List<org.eclipse.jdt.core.dom.Type> arguments = ((ParameterizedType) typeLocal).typeArguments();
          for (org.eclipse.jdt.core.dom.Type t : arguments)
          {
             result.add(new TypeImpl<O>(origin, this, t));
@@ -269,10 +269,10 @@ public class TypeImpl<O extends JavaType<O>> implements Type<O>
 
    private int getExtraDimensions()
    {
-      ASTNode parent = type.getParent();
-      if (parent instanceof FieldDeclaration)
+      ASTNode parentLocal = type.getParent();
+      if (parentLocal instanceof FieldDeclaration)
       {
-         for (Object f : ((FieldDeclaration) parent).fragments())
+         for (Object f : ((FieldDeclaration) parentLocal).fragments())
          {
             if (f instanceof VariableDeclarationFragment)
             {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:HiddenFieldCheck Local variables should not shadow class fields.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AHiddenFieldCheck
Please let me know if you have any questions.
George Kankava