### PR TITLE
squid:S1197 Array designators "[]" should be on the type, not the variable

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Strings.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Strings.java
@@ -207,9 +207,9 @@ public class Strings
          m = t.length();
       }
 
-      int p[] = new int[n + 1]; // 'previous' cost array, horizontally
-      int d[] = new int[n + 1]; // cost array, horizontally
-      int _d[]; // placeholder to assist in swapping p and d
+      int[] p = new int[n + 1]; // 'previous' cost array, horizontally
+      int[] d = new int[n + 1]; // cost array, horizontally
+      int[] _d; // placeholder to assist in swapping p and d
 
       // indexes into strings s and t
       int i; // iterates through s
@@ -347,9 +347,9 @@ public class Strings
          m = t.length();
       }
 
-      int p[] = new int[n + 1]; // 'previous' cost array, horizontally
-      int d[] = new int[n + 1]; // cost array, horizontally
-      int _d[]; // placeholder to assist in swapping p and d
+      int[] p = new int[n + 1]; // 'previous' cost array, horizontally
+      int[] d = new int[n + 1]; // cost array, horizontally
+      int[] _d; // placeholder to assist in swapping p and d
 
       // fill in starting table values
       int boundary = Math.min(n, threshold) + 1;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1197 Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1197
Please let me know if you have any questions.
George Kankava