### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Assert.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Assert.java
@@ -12,6 +12,8 @@ package org.jboss.forge.roaster.model.util;
  */
 public class Assert
 {
+   private Assert() {}
+
    public static void isTrue(boolean condition, String message)
    {
       if (!condition)

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/DesignPatterns.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/DesignPatterns.java
@@ -28,6 +28,8 @@ import org.jboss.forge.roaster.model.source.PropertySource;
  */
 public class DesignPatterns
 {
+   private DesignPatterns() {}
+
    /**
     * Creates a class based on the Builder Design pattern.
     * 

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Methods.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Methods.java
@@ -24,6 +24,8 @@ import org.jboss.forge.roaster.model.source.ParameterSource;
  */
 public class Methods
 {
+   private Methods() {}
+
    /**
     * Implement the abstract methods present in a {@link MethodHolder} to the specified {@link MethodHolderSource}
     * 

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Refactory.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Refactory.java
@@ -25,6 +25,8 @@ public class Refactory
 {
    private static final String RETURN_FALSE = " return false;";
 
+   private Refactory() {}
+
     /**
     * Generates a getXXX and setXXX method for the supplied field
     *

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -151,6 +151,8 @@ public class Types
             "SafeVarargs",
             "SuppressWarnings");
 
+   private Types() {}
+
    public static boolean areEquivalent(String left, String right)
    {
       if ((left == null) && (right == null))


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava