### PR TITLE
multiple code improvements: squid:S1118, squid:S1155, squid:S1488

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/Roaster.java
+++ b/api/src/main/java/org/jboss/forge/roaster/Roaster.java
@@ -31,6 +31,8 @@ import org.jboss.forge.roaster.spi.JavaParser;
  */
 public final class Roaster
 {
+   private Roaster() {}
+
    private static List<JavaParser> parsers;
    private static List<FormatterProvider> formatters;
 
@@ -46,7 +48,7 @@ public final class Roaster
                parsers.add(p);
             }
          }
-         if (parsers.size() == 0)
+         if (parsers.isEmpty())
          {
             throw new IllegalStateException("No instances of [" + JavaParser.class.getName()
                      + "] were found on the classpath.");
@@ -67,7 +69,7 @@ public final class Roaster
                formatters.add(p);
             }
          }
-         if (formatters.size() == 0)
+         if (formatters.isEmpty())
          {
             throw new IllegalStateException("No instances of [" + FormatterProvider.class.getName()
                      + "] were found on the classpath.");
@@ -173,8 +175,7 @@ public final class Roaster
 
          if (type.isInstance(unit.getGoverningType()))
          {
-            final T result = (T) unit.getGoverningType();
-            return result;
+            return (T) unit.getGoverningType();
          }
          else if (unit != null)
          {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava