### PR TITLE
multiple code improvements: squid:S1066, squid:S1155, squid:S1118, squid:S2325

### DIFF
--- a/dist/src/main/java/org/jboss/forge/roaster/Bootstrap.java
+++ b/dist/src/main/java/org/jboss/forge/roaster/Bootstrap.java
@@ -139,7 +139,7 @@ public class Bootstrap
       }
    }
 
-   private String help()
+   private static String help()
    {
       StringBuilder sb = new StringBuilder();
       sb.append("Usage: roaster [OPTION]... FILES ... \n");

--- a/impl/src/main/java/org/jboss/forge/roaster/model/ast/AnnotationAccessor.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/ast/AnnotationAccessor.java
@@ -161,7 +161,7 @@ public class AnnotationAccessor<O extends JavaSource<O>, T>
       removeAllAnnotations(variableDeclaration.modifiers());
    }
 
-   private void removeAllAnnotations(final List<?> modifiers)
+   private static void removeAllAnnotations(final List<?> modifiers)
    {
       Iterator<?> iterator = modifiers.iterator();
       while (iterator.hasNext())
@@ -244,7 +244,7 @@ public class AnnotationAccessor<O extends JavaSource<O>, T>
       return null;
    }
 
-   private List<?> getModifiers(final ASTNode body)
+   private static List<?> getModifiers(final ASTNode body)
    {
       if (body instanceof BodyDeclaration)
       {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/ast/ModifierAccessor.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/ast/ModifierAccessor.java
@@ -90,7 +90,7 @@ public class ModifierAccessor
    }
 
    @SuppressWarnings("unchecked")
-   private List<Modifier> getInternalModifiers(final ASTNode body)
+   private static List<Modifier> getInternalModifiers(final ASTNode body)
    {
       if (body instanceof BodyDeclaration)
       {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -368,10 +368,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       }
 
       // No import matches and no wild-card/on-demand import matches means this class is in the same package.
-      if (Types.isSimpleName(result))
+      if (Types.isSimpleName(result) && getPackage() != null)
       {
-         if (getPackage() != null)
-            result = getPackage() + "." + result;
+         result = getPackage() + "." + result;
       }
 
       return result;
@@ -387,7 +386,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
             resolvers.add(r);
          }
       }
-      if (resolvers.size() == 0)
+      if (resolvers.isEmpty())
       {
          throw new IllegalStateException("No instances of [" + WildcardImportResolver.class.getName()
                   + "] were found on the classpath.");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 Utility classes should not have public constructors.
squid:S2325 private methods that don't access instance data should be static.
squid:S1066 Collapsible "if" statements should be merged.
squid:S1155 Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1066
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
Please let me know if you have any questions.
George Kankava