### PR TITLE
add tests for necessary fully qualified supertypes

### DIFF
--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
@@ -312,6 +312,15 @@ public abstract class JavaClassTestBase
 
       source.setSuperType(getClass());
       assertEquals(getClass().getName(), source.getSuperType());
+      
+      // test if identical simple names work
+      source = Roaster.create(JavaClassSource.class);
+      source.setName("Foo").setSuperType("bar.Foo");
+      assertEquals("test if super type is not changed", "bar.Foo", source.getSuperType());
+      assertEquals("test if import is not added", 0, source.getImports().size());
+      source.setSuperType("foo.Bar");
+      assertEquals("test if super type is simplified", "Bar", source.getSuperType());
+      assertEquals("test if import is added", source.getImports().get(0).toString(), "foo.Bar");      
    }
 
    @Test


### PR DESCRIPTION
I have added some test cases that should pass. However, I was unable to fix the behavior of Roaster as my experience with JDT is limited. The method that should fix this is:
`org.jboss.forge.roaster.model.impl.JavaClassImpl.setSuperType()`. The method should include an addition check for identical simple names of the class of which the supertype is set as well as the supertype itself. If the simple names are identical then a fully qualified name should be set as the super type (and no import).
