### PR TITLE
ROASTER-110: Allow nested generic types for method return types

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -205,8 +205,15 @@ public class Types
       if (isGeneric(type))
       {
          final List<String> simpleParameters = new ArrayList<String>();
-         for (String typeParameter : getGenericsTypeParameter(type).split(","))
+         StringTokenizer tok = new StringTokenizer(getGenericsTypeParameter(type), ",");
+         while (tok.hasMoreTokens())
          {
+            String typeParameter = tok.nextToken();
+            while (incompleteGenerics(typeParameter) && tok.hasMoreElements())
+            {
+               typeParameter += ',' + tok.nextToken();
+            }
+
             String simpleType;
             typeParameter = typeParameter.trim();
             if ("?".equals(typeParameter))
@@ -318,7 +325,7 @@ public class Types
          String typeArg = tok.nextToken();
          while (incompleteGenerics(typeArg) && tok.hasMoreElements())
          {
-            typeArg += tok.nextToken();
+            typeArg += ',' + tok.nextToken();
          }
 
          if (!validateNameWithGenerics(typeArg))

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/MethodReturnTypeTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/MethodReturnTypeTest.java
@@ -351,14 +351,13 @@ public class MethodReturnTypeTest
    }
 
    @Test
-   @Ignore("ROASTER-110")
    public void testNestedTypedParametersShouldNotThrowException() throws Exception
    {
       final JavaClassSource javaClass = Roaster.create(JavaClassSource.class).setPackage("com.scratch")
                .setName("Example");
       final MethodSource<JavaClassSource> method = javaClass.addMethod().setName("createMap")
-               .setReturnType("java.util.Map<String,java.util.Map<String,String>>");
-      Assert.assertEquals("java.util.Map<String,java.util.Map<String,String>>",
+               .setReturnType("java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>>");
+      Assert.assertEquals("java.util.Map<String,Map<String,String>>",
                method.getReturnType().getQualifiedNameWithGenerics());
    }
 }


### PR DESCRIPTION
The tokens for generics were incomplete when using them as a return type. This has been fixed.

However, I had to modify the test case so it makes the same assumption as `testReturnTypeShouldKeepGenerics` and `testGetReturnTypeReturnsFullTypeForJavaLangGeneric`. Right now, the generics are not returned qualified despite the fact that this is mentioned in the documentation:

> Returns the type's qualified name, preserving type parameters (which are also qualified)