### PR TITLE
updated class path

### DIFF
--- a/dist/src/main/resources/bin/roaster
+++ b/dist/src/main/resources/bin/roaster
@@ -157,6 +157,6 @@ if $cygwin; then
 fi
 
 roaster_exec_cmd="\"$JAVACMD\" $ROASTER_DEBUG_ARGS $ROASTER_OPTS \"-Droaster.home=${ROASTER_HOME}\" \
-   -cp \"${ROASTER_HOME}/lib/*\" $ROASTER_MAIN_CLASS"
+   -cp \"${ROASTER_HOME}\" $ROASTER_MAIN_CLASS"
 
 eval $roaster_exec_cmd "$QUOTED_ARGS"

--- a/dist/src/main/resources/bin/roaster
+++ b/dist/src/main/resources/bin/roaster
@@ -157,6 +157,6 @@ if $cygwin; then
 fi
 
 roaster_exec_cmd="\"$JAVACMD\" $ROASTER_DEBUG_ARGS $ROASTER_OPTS \"-Droaster.home=${ROASTER_HOME}\" \
-   -cp \"${ROASTER_HOME}\" $ROASTER_MAIN_CLASS"
+   -cp \"${ROASTER_HOME}/lib/*:${ROASTER_HOME}\" $ROASTER_MAIN_CLASS"
 
 eval $roaster_exec_cmd "$QUOTED_ARGS"

--- a/dist/src/main/resources/bin/roaster.bat
+++ b/dist/src/main/resources/bin/roaster.bat
@@ -150,7 +150,7 @@ goto runRoaster
 
 set ROASTER_MAIN_CLASS=org.jboss.forge.roaster.Bootstrap
 %ROASTER_JAVA_EXE% %ROASTER_DEBUG_ARGS% %ROASTER_OPTS% "-Droaster.standalone=true" "-Droaster.home=%ROASTER_HOME%" ^
-   -cp ".;%ROASTER_HOME%\lib\*" %ROASTER_MAIN_CLASS% %ROASTER_CMD_LINE_ARGS%
+   -cp ".;%ROASTER_HOME%\lib\*;%ROASTER_HOME%" %ROASTER_MAIN_CLASS% %ROASTER_CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end
 


### PR DESCRIPTION
The class path pointed to an non existing directory and could not find the `Boostrap` class. 

_problem_
When `./roaster` command was called, it gave error:
`Error: Could not find or load main class org.jboss.forge.roaster.Bootstrap`

_steps to reproduce_
* `git clone git@github.com:forge/roaster.git`
* `cd roaster`
* `mvn compile`
* `cd dist/target/classes/bin`
* `./roaster`
the error previously mentioned happens at this point.