### PR TITLE
ROASTER-117: Allow nested generic types in setSuperType

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/source/Importer.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/Importer.java
@@ -35,7 +35,8 @@ public interface Importer<O extends JavaSource<O>>
    boolean requiresImport(Class<?> type);
 
    /**
-    * Return whether or not this {@link O} would require an import to reference the given fully-qualified class name.
+    * Return whether or not this {@link O} would require an import to reference the given fully-qualified class name. If
+    * the type is generic, the generic parts are also checked in a recursive way.
     */
    boolean requiresImport(String type);
 
@@ -82,7 +83,7 @@ public interface Importer<O extends JavaSource<O>>
 
    /**
     * Add an import by qualified class name. (E.g: "com.example.Imported") unless it is in the provided 'java.lang.*'
-    * package.
+    * package. In the case of a generic type, the classes used are recursively also imported.
     */
    Import addImport(final String className);
 
@@ -104,19 +105,17 @@ public interface Importer<O extends JavaSource<O>>
    /**
     * Ensures the type passed as argument is included in the list of imports for this java source. The method will also
     * recursively import parameter types. This method is idempotent: if a type has already been imported, no further
-    * action will be required. The method returns an {@link Import} object which should be used to reference the imported type in the code
-    * if the import operation is valid or null if one of the following conditions is met:
+    * action will be required. The method returns an {@link Import} object which should be used to reference the
+    * imported type in the code if the import operation is valid or null if one of the following conditions is met:
     *
-    * - This type is the same type as the Class name
-    * - This type cannot be added to the import statement because it references a type with the same name but from a different package
-    * - This type belongs to the java.lang package
+    * - This type is the same type as the Class name - This type cannot be added to the import statement because it
+    * references a type with the same name but from a different package - This type belongs to the java.lang package
     *
     * @param type The {@link org.jboss.forge.roaster.model.Type} to be imported.
     * @return The name (simple or fully qualified) that should be used to reference the imported type in the code or
-    * null if the import could not be performed due to one of the following conditions is met:
-    * - This type is the same type as the Class name
-    * - This type cannot be added to the import statement because it references a type with the same name but from a different package
-    * - This type belongs to the java.lang package
+    *         null if the import could not be performed due to one of the following conditions is met: - This type is
+    *         the same type as the Class name - This type cannot be added to the import statement because it references
+    *         a type with the same name but from a different package - This type belongs to the java.lang package
     * @seeAlso org.jboss.forge.roaster.model.Type
     */
    Import addImport(Type<?> type);

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -425,9 +425,9 @@ public class Types
       {
          return true;
       }
-      if(!type.endsWith("]"))
+      if (!type.endsWith("]"))
       {
-          return false;
+         return false;
       }
       Matcher matcher = SIMPLE_ARRAY_PATTERN.matcher(type);
       if (matcher.find())
@@ -472,9 +472,9 @@ public class Types
 
    private static boolean isClassArray(String type)
    {
-      if( type == null || type.length() == 0 || type.charAt(0) != '[' )
+      if (type == null || type.length() == 0 || type.charAt(0) != '[')
       {
-          return false;
+         return false;
       }
       Matcher matcher = CLASS_ARRAY_PATTERN.matcher(type);
       return matcher.find();
@@ -650,13 +650,45 @@ public class Types
     */
    public static String[] splitGenerics(String typeName)
    {
-      typeName = typeName.replaceAll("\\s", "");
-      int begin = typeName.indexOf('<');
-      int end = typeName.indexOf('>');
+      String workingString = typeName.replaceAll("\\s", "");
+      int begin = workingString.indexOf('<');
+      int end = workingString.lastIndexOf('>');
+
       if (begin == -1 || end == -1)
       {
          return new String[0];
       }
-      return GENERIC_TYPE_PATTERN.split(typeName.substring(begin + 1, end));
+
+      workingString = workingString.substring(begin + 1, end);
+      int depth = 0;
+      final StringBuilder currentPart = new StringBuilder();
+      final List<String> genericParts = new ArrayList<>();
+      for (int currentIndex = 0; currentIndex < workingString.length(); currentIndex++)
+      {
+         char currentChar = workingString.charAt(currentIndex);
+         if (currentChar == ',' && depth == 0)
+         {
+            genericParts.add(currentPart.toString());
+            currentPart.setLength(0);
+            continue;
+         }
+         else if (currentChar == '<')
+         {
+            depth++;
+
+         }
+         else if (currentChar == '>')
+         {
+            depth--;
+         }
+         currentPart.append(currentChar);
+      }
+
+      if (currentPart.length() != 0)
+      {
+         genericParts.add(currentPart.toString());
+      }
+
+      return genericParts.toArray(new String[genericParts.size()]);
    }
 }

--- a/api/src/test/java/org/jboss/forge/roaster/model/util/TypesTest.java
+++ b/api/src/test/java/org/jboss/forge/roaster/model/util/TypesTest.java
@@ -7,11 +7,14 @@
 
 package org.jboss.forge.roaster.model.util;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
 
@@ -205,5 +208,6 @@ public class TypesTest
    public void testSplitGenerics()
    {
       assertArrayEquals(new String[] { "String", "Integer" }, Types.splitGenerics("Foo<String,Integer>"));
+      assertArrayEquals(new String[] { "Bar<A>", "Bar<B>"}, Types.splitGenerics("Foo<Bar<A>, Bar<B>>"));
    }
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaClassImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaClassImpl.java
@@ -185,11 +185,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
 
          org.eclipse.jdt.core.dom.ParameterizedType pt = body.getAST().newParameterizedType(
                   body.getAST().newSimpleType(body.getAST().newSimpleName(simpleTypeDName)));
-
-         //if (Types.isQualified(type))
-         //{
             addImport(type);
-         //}
 
          for (String typeP : Types.splitGenerics(type))
          {
@@ -203,12 +199,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
       {
          final SimpleName simpleName = body.getAST().newSimpleName(Types.toSimpleName(type));
          final Type superType;
-         Import imprt = null;
-
-         //if (Types.isQualified(type))
-         //{
-            imprt = addImport(type);
-         //}
+         Import imprt = addImport(type);
 
          if (imprt == null && !Types.isSimpleName(type))
          {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaClassImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaClassImpl.java
@@ -182,24 +182,19 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
       {
          String typeD = Types.stripGenerics(type);
          String simpleTypeDName = Types.toSimpleName(typeD);
-         String typesGeneric = Types.getGenericsTypeParameter(type);
 
          org.eclipse.jdt.core.dom.ParameterizedType pt = body.getAST().newParameterizedType(
                   body.getAST().newSimpleType(body.getAST().newSimpleName(simpleTypeDName)));
 
-         if (!hasImport(typeD) && Types.isQualified(typeD))
-         {
-            addImport(typeD);
-         }
+         //if (Types.isQualified(type))
+         //{
+            addImport(type);
+         //}
 
-         for (String typeP : typesGeneric.split(","))
+         for (String typeP : Types.splitGenerics(type))
          {
             Type t = TypeImpl.fromString(Types.toSimpleName(typeP.trim()), body.getAST());
             pt.typeArguments().add(t);
-            if (!hasImport(typeP) && Types.isQualified(typeP))
-            {
-               addImport(typeP);
-            }
          }
 
          getBodyDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, pt);
@@ -210,10 +205,10 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
          final Type superType;
          Import imprt = null;
 
-         if (Types.isQualified(type))
-         {
+         //if (Types.isQualified(type))
+         //{
             imprt = addImport(type);
-         }
+         //}
 
          if (imprt == null && !Types.isSimpleName(type))
          {

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/JavaClassGenericsTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/JavaClassGenericsTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -203,12 +204,12 @@ public class JavaClassGenericsTest
    }
 
    @Test
-   @Ignore("Reproduces ROASTER-117")
-   public void testNestedGenericsInSuperType() throws Exception
+   public void testNestedGenericsInSuperType()
    {
       JavaClassSource javaClass = Roaster.create(JavaClassSource.class);
-      javaClass.setSuperType("SomeClass<java.util.Map<String,SomeOtherClass>>");
+      javaClass.setSuperType("SomeClass<java.util.Map<String,java.util.Date>>");
       Assert.assertThat(javaClass.hasImport(Map.class), is(true));
-      Assert.assertThat(javaClass.getSuperType(), equalTo("SomeClass<Map<String,SomeOtherClass>>"));
+      Assert.assertThat(javaClass.hasImport(Date.class), is(true));
+      Assert.assertThat(javaClass.getSuperType(), equalTo("SomeClass<Map<String,Date>>"));
    }
 }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
@@ -123,7 +123,7 @@ public abstract class JavaClassTestBase
       assertTrue(source.isDefaultPackage());
    }
 
-   @Test(expected = IllegalArgumentException.class)
+   @Test()
    public void testAddImportPrimitiveThrowsException()
    {
       assertNull(source.addImport(boolean.class));

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
@@ -124,8 +124,7 @@ public abstract class JavaClassTestBase
    }
 
    @Test(expected = IllegalArgumentException.class)
-   @Ignore
-   public void testAddImportPrimitiveThrowsException() throws Exception
+   public void testAddImportPrimitiveThrowsException()
    {
       assertNull(source.addImport(boolean.class));
    }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
@@ -28,6 +28,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -123,9 +124,10 @@ public abstract class JavaClassTestBase
    }
 
    @Test(expected = IllegalArgumentException.class)
+   @Ignore
    public void testAddImportPrimitiveThrowsException() throws Exception
    {
-      source.addImport(boolean.class);
+      assertNull(source.addImport(boolean.class));
    }
 
    @Test
@@ -137,10 +139,10 @@ public abstract class JavaClassTestBase
       assertEquals(List.class.getName(), source.getImports().get(1).getQualifiedName());
    }
 
-   @Test(expected = IllegalArgumentException.class)
+   @Test()
    public void testCannotAddSimpleClassImport() throws Exception
    {
-      source.addImport("List");
+      assertNull(source.addImport("List"));
    }
 
    @Test
@@ -228,6 +230,17 @@ public abstract class JavaClassTestBase
       assertFalse(source.requiresImport(String.class));
       assertTrue(source.requiresImport(Annotation.class));
       assertFalse(source.requiresImport(source.getPackage() + ".Foo"));
+   }
+   
+   @Test
+   public void testRequiresImportNested()
+   {
+     JavaClassSource source = Roaster.create(JavaClassSource.class);
+     assertTrue(source.requiresImport("package1.Class1<package2.Class2>"));
+     
+     source.addImport("package1.Class1<?>");
+     assertTrue(source.getImports().size() == 1);
+     assertTrue(source.requiresImport("package1.Class1<package2.Class2>"));
    }
 
    @Test

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/WildCardImportsTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/WildCardImportsTest.java
@@ -6,6 +6,8 @@
  */
 package org.jboss.forge.test.roaster.model.common;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.forge.roaster.Roaster;
@@ -26,6 +28,14 @@ public class WildCardImportsTest
       javaClass.addImport("org.junit.Assert.*");
       assertTrue(javaClass.getImport("org.junit.Assert") != null);
       assertTrue(javaClass.getImport("org.junit.Assert").isWildcard());
+   }
+   
+   @Test
+   public void testImportWithGenerics()
+   {
+      JavaClassSource javaClass = Roaster.create(JavaClassSource.class);
+      javaClass.addImport("package1.Class1<package2.Class2>");
+      assertThat(javaClass.getImports().size(), is(2));
    }
 
    @Test


### PR DESCRIPTION
Hi,
this pull request is to solve ROASTER-117.
I did the following:
* improve the splitGeneric method to with nested generics
* change the setSuperType method to use the splitGeneric  method
* change the requireImport method to check also the type parameters
* change the addImport method to also import the type parameters

Since this touching core components, please take a closer look to it. I want to avoid any regressions or unexpected behaviour. Currently all test are green, but maybe you find something.

Best regards,
Kai