### PR TITLE
Roaster 23: Improve the resolve type logic and fix wildcard import problems

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/source/Import.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/Import.java
@@ -17,13 +17,48 @@ import org.jboss.forge.roaster.Internal;
  */
 public interface Import extends Internal, StaticCapableSource<Import>
 {
+   public static final String WILDCARD = "*";
+
+   /**
+    * Returns the package part of a import.
+    * 
+    * @return the package of this import
+    */
    String getPackage();
 
+   /**
+    * Returns the simple name of a import.
+    * 
+    * @return the simple class name of a import or {@link #WILDCARD}, if this is a wildcard import.
+    * @see Class#getSimpleName()
+    */
    String getSimpleName();
 
+   /**
+    * Returns the qualified name, so it's the same as '{@code getPackage() + "." + getSimpleName()}'. In the case this
+    * is a wildcard import, the package part is returned.
+    * 
+    * @return the qualified name or the packge if this is a wildcar import
+    */
    String getQualifiedName();
 
+   /**
+    * Checks if this import is a wildcard ({@code *}) import.
+    * 
+    * @return true if this is a wildcard import, false otherwise
+    */
    boolean isWildcard();
 
+   /**
+    * Sets the data of this import object. The data is the part of a {@code import} statement which is between
+    * {@code import} and {@code ;}.
+    * 
+    * <p>
+    * This method is <b>not</b> intended to be called from externally.
+    * </p>
+    * 
+    * @param name the actual data of the import
+    * @return {@code this}
+    */
    Import setName(final String name);
 }

--- a/api/src/main/java/org/jboss/forge/roaster/model/source/Importer.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/Importer.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.Type;
+import org.jboss.forge.roaster.spi.WildcardImportResolver;
 
 /**
  * Defines the aspect of {@link JavaSource} that handles type imports.
@@ -77,7 +78,18 @@ public interface Importer<O extends JavaSource<O>>
 
    /**
     * Given a simple or qualified type, resolve that type against the available imports and return the referenced type.
-    * If the type cannot be resolved, return the given type unchanged.
+    * The resolving processing order is as followed:
+    * <ol>
+    * <li>If the type is primitive or full qualified, the type is returned as it</li>
+    * <li>Find the type in the imports</li>
+    * <li>If only one wildcard import is used, use this import for resolving</li>
+    * <li>Use the available {@link WildcardImportResolver}. The first qualified name is used</li>
+    * <li>The current package if defined is used for resolving</li>
+    * <li>The type is returned as it</li>
+    * </ol>
+    * If the type is returned as it, maybe parts which can hinder we matching process like generic's are stripped of.
+    * @param type the type to resolve
+    * @return the (resolved) type
     */
    String resolveType(String type);
 

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/ImportImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/ImportImpl.java
@@ -6,6 +6,8 @@
  */
 package org.jboss.forge.roaster.model.impl;
 
+import java.util.Objects;
+
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ImportDeclaration;
@@ -42,6 +44,10 @@ public class ImportImpl implements Import
    @Override
    public String getSimpleName()
    {
+      if (isWildcard())
+      {
+         return WILDCARD;
+      }
       return Types.toSimpleName(imprt.getName().getFullyQualifiedName());
    }
 
@@ -94,10 +100,7 @@ public class ImportImpl implements Import
    @Override
    public int hashCode()
    {
-      final int prime = 31;
-      int result = 1;
-      result = (prime * result) + ((imprt == null) ? 0 : imprt.hashCode());
-      return result;
+      return Objects.hashCode(imprt);
    }
 
    @Override
@@ -122,6 +125,10 @@ public class ImportImpl implements Import
    @Override
    public String getPackage()
    {
+      if (isWildcard())
+      {
+         return imprt.getName().getFullyQualifiedName();
+      }
       return Types.getPackage(getQualifiedName());
    }
 }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/ImportTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/ImportTest.java
@@ -1,12 +1,13 @@
 package org.jboss.forge.test.roaster.model;
 
-import org.assertj.core.api.Assertions;
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class ImportTest
 {
@@ -20,5 +21,15 @@ public class ImportTest
       assertThat(imprtOne).isNotNull();
       assertThat(imprtTwo).isNull();
    }
-
+   
+   @Test
+   public void testWildCardImportReturnsCorrectData() {
+      final JavaClassSource javaClassSource = Roaster.create(JavaClassSource.class);
+      String pckage = "packageOne.packageTwo";
+      final Import imprt = javaClassSource.addImport(pckage + ".*");
+      assertThat(imprt.isWildcard(), is(true));
+      assertThat(imprt.getPackage(), is(pckage));
+      assertThat(imprt.getSimpleName(), is(Import.WILDCARD));
+      assertThat(imprt.getQualifiedName(), is(pckage));
+   }
 }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
@@ -28,7 +28,6 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -230,16 +229,47 @@ public abstract class JavaClassTestBase
       assertTrue(source.requiresImport(Annotation.class));
       assertFalse(source.requiresImport(source.getPackage() + ".Foo"));
    }
-   
+
+   @Test
+   public void testResolvedType()
+   {
+      JavaClassSource source = Roaster.create(JavaClassSource.class);
+      String type = "ClassA";
+
+      // if the type is qualified or primitive, return the type as it
+      assertThat(source.resolveType(boolean.class.getName()), is(boolean.class.getName()));
+      assertThat(source.resolveType("package1.Class1"), is("package1.Class1"));
+
+      // if the source has no imports & no package, return the type as it
+      assertThat(source.resolveType(type), is(type));
+
+      // if the source has a package, use it
+      String pckage = "myPackage";
+      source.setPackage(pckage);
+      assertThat(source.resolveType(type), is(pckage + "." + type));
+
+      // TODO add tests for wildcard resolver
+
+      // test for single wildcard
+      String wildcarPacke = "wildcard.pckage";
+      source.addImport(wildcarPacke + ".*");
+      assertThat(source.resolveType(type), is(wildcarPacke + "." + type));
+
+      // test direct import resolving
+      String directImport = "direct.imprt." + type;
+      source.addImport(directImport);
+      assertThat(source.resolveType(type), is(directImport));
+   }
+
    @Test
    public void testRequiresImportNested()
    {
-     JavaClassSource source = Roaster.create(JavaClassSource.class);
-     assertTrue(source.requiresImport("package1.Class1<package2.Class2>"));
-     
-     source.addImport("package1.Class1<?>");
-     assertTrue(source.getImports().size() == 1);
-     assertTrue(source.requiresImport("package1.Class1<package2.Class2>"));
+      JavaClassSource source = Roaster.create(JavaClassSource.class);
+      assertTrue(source.requiresImport("package1.Class1<package2.Class2>"));
+
+      source.addImport("package1.Class1<?>");
+      assertTrue(source.getImports().size() == 1);
+      assertTrue(source.requiresImport("package1.Class1<package2.Class2>"));
    }
 
    @Test


### PR DESCRIPTION
Hi,
I added the following:
* enhancement of the resolveType logic (performance)
* add a special case to resolveType where only one wildcard import is present
* some tests & javadoc
* I needed to fix some problems inside the ImportImpl since missing handling for wildcards preventing my change

Please review.
I add a issue to revisit the getQualifiedName logic in the import since it returns the package for wildcard imports which is not very nice.
Also I know that I added a TODO in one test for wildcard resolvers (so this TODO is there by purpose but I was not able to add a import resolver in a easy way).

Best regards,
Kai