### PR TITLE
Avoid duplicate code in JavaPackageInfoImpl

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -7,796 +7,48 @@
 package org.jboss.forge.roaster.model.impl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.compiler.IProblem;
+import java.util.Objects;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
-import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.EnumDeclaration;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
-import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeParameter;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jface.text.Document;
-import org.eclipse.text.edits.TextEdit;
 import org.jboss.forge.roaster.ParserException;
 import org.jboss.forge.roaster.Roaster;
-import org.jboss.forge.roaster.model.Annotation;
 import org.jboss.forge.roaster.model.JavaType;
-import org.jboss.forge.roaster.model.SyntaxError;
 import org.jboss.forge.roaster.model.Type;
-import org.jboss.forge.roaster.model.Visibility;
-import org.jboss.forge.roaster.model.ast.AnnotationAccessor;
 import org.jboss.forge.roaster.model.ast.ModifierAccessor;
 import org.jboss.forge.roaster.model.ast.TypeDeclarationFinderVisitor;
-import org.jboss.forge.roaster.model.source.AnnotationSource;
-import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaDocSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.StaticCapableSource;
 import org.jboss.forge.roaster.model.source.TypeHolderSource;
-import org.jboss.forge.roaster.model.util.Formatter;
 import org.jboss.forge.roaster.model.util.Strings;
-import org.jboss.forge.roaster.model.util.Types;
 import org.jboss.forge.roaster.spi.JavaParserImpl;
-import org.jboss.forge.roaster.spi.WildcardImportResolver;
 
 /**
- * Represents a Java Source File
+ * Represents a Java Source File which allow types
  *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 @SuppressWarnings("unchecked")
-public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
-         JavaSource<O>, TypeHolderSource<O>, StaticCapableSource<O>
+
+public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSourceImpl<O> implements
+         TypeHolderSource<O>, StaticCapableSource<O>
 {
-   private final AnnotationAccessor<O, O> annotations = new AnnotationAccessor<O, O>();
-   private final ModifierAccessor modifiers = new ModifierAccessor();
-
-   protected final Document document;
-   protected final CompilationUnit unit;
    protected final BodyDeclaration body;
-   protected final JavaSource<?> enclosingType;
-
-   private static List<WildcardImportResolver> resolvers;
+   private final ModifierAccessor modifiers = new ModifierAccessor();
 
    protected AbstractJavaSource(JavaSource<?> enclosingType, final Document document, final CompilationUnit unit,
             BodyDeclaration body)
    {
-      this.enclosingType = enclosingType == null ? this : enclosingType;
-      this.document = document;
-      this.unit = unit;
+      super(enclosingType, document, unit);
       this.body = body;
-   }
-
-   @Override
-   public JavaSource<?> getEnclosingType()
-   {
-      return enclosingType;
-   }
-
-   /*
-    * Annotation modifiers
-    */
-   @Override
-   public AnnotationSource<O> addAnnotation()
-   {
-      return annotations.addAnnotation(this, getBodyDeclaration());
-   }
-
-   @Override
-   public AnnotationSource<O> addAnnotation(final Class<? extends java.lang.annotation.Annotation> clazz)
-   {
-      return annotations.addAnnotation(this, getBodyDeclaration(), clazz.getName());
-   }
-
-   @Override
-   public AnnotationSource<O> addAnnotation(final String className)
-   {
-      return annotations.addAnnotation(this, getBodyDeclaration(), className);
-   }
-
-   @Override
-   public List<AnnotationSource<O>> getAnnotations()
-   {
-      return annotations.getAnnotations(this, getBodyDeclaration());
-   }
-
-   @Override
-   public boolean hasAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
-   {
-      return annotations.hasAnnotation(this, getBodyDeclaration(), type.getName());
-   }
-
-   @Override
-   public boolean hasAnnotation(final String type)
-   {
-      return annotations.hasAnnotation(this, getBodyDeclaration(), type);
-   }
-
-   @Override
-   public O removeAnnotation(final Annotation<O> annotation)
-   {
-      return (O) annotations.removeAnnotation(this, getBodyDeclaration(), annotation);
-   }
-
-   @Override
-   public void removeAllAnnotations()
-   {
-      annotations.removeAllAnnotations(getBodyDeclaration());
-   }
-
-   @Override
-   public AnnotationSource<O> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
-   {
-      return annotations.getAnnotation(this, getBodyDeclaration(), type);
-   }
-
-   @Override
-   public AnnotationSource<O> getAnnotation(final String type)
-   {
-      return annotations.getAnnotation(this, getBodyDeclaration(), type);
-   }
-
-   /*
-    * Import modifiers
-    */
-
-   @Override
-   public Import addImport(final Class<?> type)
-   {
-      return addImport(type.getCanonicalName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> Import addImport(final T type)
-   {
-      String qualifiedName = type.getQualifiedName();
-      return this.addImport(qualifiedName);
-   }
-
-   @Override
-   public Import addImport(final Import imprt)
-   {
-      return addImport(imprt.getQualifiedName()).setStatic(imprt.isStatic());
-   }
-
-   @Override
-   public Import addImport(final String className)
-   {
-      String strippedClassName = Types.stripGenerics(Types.stripArray(className));
-
-      if (Types.isGeneric(className))
-      {
-         for (String genericPart : Types.splitGenerics(className))
-         {
-            if (Types.isQualified(genericPart))
-               addImport(genericPart);
-         }
-      }
-
-      Import imprt;
-      if (!hasImport(strippedClassName) && validImport(strippedClassName))
-      {
-         imprt = new ImportImpl(this).setName(strippedClassName);
-         unit.imports().add(imprt.getInternal());
-      }
-      else if (hasImport(strippedClassName))
-      {
-         imprt = getImport(strippedClassName);
-      }
-      else
-      {
-         imprt = null;
-      }
-      return imprt;
-   }
-
-   @Override
-   public Import getImport(final String className)
-   {
-      List<Import> imports = getImports();
-      for (Import imprt : imports)
-      {
-         if (imprt.getQualifiedName().equals(className) || imprt.getSimpleName().equals(className))
-         {
-            return imprt;
-         }
-      }
-      return null;
-   }
-
-   @Override
-   public Import getImport(final Class<?> type)
-   {
-      return getImport(type.getName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> Import getImport(final T type)
-   {
-      return getImport(type.getQualifiedName());
-   }
-
-   @Override
-   public Import getImport(final Import imprt)
-   {
-      return getImport(imprt.getQualifiedName());
-   }
-
-   @Override
-   public List<Import> getImports()
-   {
-      List<Import> results = new ArrayList<Import>();
-
-      for (ImportDeclaration i : (List<ImportDeclaration>) unit.imports())
-      {
-         results.add(new ImportImpl(this, i));
-      }
-
-      return Collections.unmodifiableList(results);
-   }
-
-   @Override
-   public boolean hasImport(final Class<?> type)
-   {
-      return hasImport(type.getName());
-   }
-
-   @Override
-   public <T extends JavaType<T>> boolean hasImport(final T type)
-   {
-      return hasImport(type.getQualifiedName());
-   }
-
-   @Override
-   public boolean hasImport(final Import imprt)
-   {
-      return hasImport(imprt.getQualifiedName());
-   }
-
-   @Override
-   public boolean hasImport(final String type)
-   {
-      String resultType = type;
-      if (Types.isArray(type))
-      {
-         resultType = Types.stripArray(type);
-      }
-      if (Types.isGeneric(type))
-      {
-         resultType = Types.stripGenerics(type);
-      }
-      return getImport(resultType) != null;
-   }
-
-   @Override
-   public boolean requiresImport(final Class<?> type)
-   {
-      return requiresImport(type.getName());
-   }
-
-   @Override
-   public boolean requiresImport(final String type)
-   {
-      boolean requiresImport = false;
-      String resultType = type;
-      if (Types.isArray(resultType))
-      {
-         resultType = Types.stripArray(resultType);
-      }
-      if (Types.isGeneric(resultType))
-      {
-         for (String genericPart : Types.splitGenerics(resultType))
-         {
-            requiresImport |= requiresImport(genericPart);
-         }
-         resultType = Types.stripGenerics(resultType);
-      }
-      requiresImport |= !(!validImport(resultType)
-               || hasImport(resultType)
-               || Types.isJavaLang(resultType)
-               || Strings.areEqual(getPackage(), Types.getPackage(resultType)));
-      return requiresImport;
-   }
-
-   @Override
-   public String resolveType(final String type)
-   {
-      String original = type;
-      String result = type;
-
-      // Strip away any characters that might hinder the type matching process
-      if (Types.isArray(result))
-      {
-         original = Types.stripArray(result);
-         result = Types.stripArray(result);
-      }
-
-      if (Types.isGeneric(result))
-      {
-         original = Types.stripGenerics(result);
-         result = Types.stripGenerics(result);
-      }
-
-      if (Types.isPrimitive(result))
-      {
-         return result;
-      }
-
-      // Check for direct import matches first since they are the fastest and least work-intensive
-      if (Types.isSimpleName(result))
-      {
-         if (!hasImport(result) && Types.isJavaLang(result))
-         {
-            result = "java.lang." + result;
-         }
-
-         if (result.equals(original))
-         {
-            for (Import imprt : getImports())
-            {
-               if (Types.areEquivalent(result, imprt.getQualifiedName()))
-               {
-                  result = imprt.getQualifiedName();
-                  break;
-               }
-            }
-         }
-      }
-
-      // If we didn't match any imports directly, we might have a wild-card/on-demand import.
-      if (Types.isSimpleName(result))
-      {
-         for (Import imprt : getImports())
-         {
-            if (imprt.isWildcard())
-            {
-               // TODO warn if no wild-card resolvers are configured
-               // TODO Test wild-card/on-demand import resolving
-               for (WildcardImportResolver r : getImportResolvers())
-               {
-                  result = r.resolve(this, result);
-                  if (Types.isQualified(result))
-                     break;
-               }
-            }
-         }
-      }
-
-      // No import matches and no wild-card/on-demand import matches means this class is in the same package.
-      if (Types.isSimpleName(result) && getPackage() != null)
-      {
-         result = getPackage() + "." + result;
-      }
-
-      return result;
-   }
-
-   private List<WildcardImportResolver> getImportResolvers()
-   {
-      if (resolvers == null)
-      {
-         resolvers = new ArrayList<WildcardImportResolver>();
-         for (WildcardImportResolver r : ServiceLoader.load(WildcardImportResolver.class, getClass().getClassLoader()))
-         {
-            resolvers.add(r);
-         }
-      }
-      if (resolvers.isEmpty())
-      {
-         throw new IllegalStateException("No instances of [" + WildcardImportResolver.class.getName()
-                  + "] were found on the classpath.");
-      }
-      return resolvers;
-   }
-
-   private boolean validImport(final String type)
-   {
-      String className = Types.toSimpleName(type);
-      // check if this class name is equal to the class to import
-      if (className.equals(getName()))
-      {
-         return false;
-      }
-      // check if any import has the same class name
-      for (final Import imprt : getImports())
-      {
-         String importClassName = imprt.getSimpleName();
-         if (importClassName.equals(className))
-         {
-            return false;
-         }
-      }
-      return !Strings.isNullOrEmpty(type) && !Types.isPrimitive(type) && !Strings.isNullOrEmpty(Types.getPackage(type));
-   }
-
-   @Override
-   public O removeImport(final String name)
-   {
-      for (Import i : getImports())
-      {
-         if (i.getQualifiedName().equals(name))
-         {
-            removeImport(i);
-            break;
-         }
-      }
-      return (O) this;
-   }
-
-   @Override
-   public O removeImport(final Class<?> clazz)
-   {
-      return removeImport(clazz.getName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> O removeImport(final T type)
-   {
-      return removeImport(type.getQualifiedName());
-   }
-
-   @Override
-   public O removeImport(final Import imprt)
-   {
-      Object internal = imprt.getInternal();
-      if (unit.imports().contains(internal))
-      {
-         unit.imports().remove(internal);
-      }
-      return (O) this;
-   }
-
-   protected AbstractTypeDeclaration getBodyDeclaration()
-   {
-      if (body instanceof AbstractTypeDeclaration)
-         return (AbstractTypeDeclaration) body;
-      throw new ParserException("Source body was not of the expected type.");
-   }
-
-   /*
-    * Name modifiers
-    */
-   @Override
-   public String getName()
-   {
-      return getBodyDeclaration().getName().getIdentifier();
-   }
-
-   @SuppressWarnings("rawtypes")
-   @Override
-   public O setName(final String name)
-   {
-      AbstractTypeDeclaration typeDeclaration = getBodyDeclaration();
-      TypeImpl<O> type = new TypeImpl(this, null, name);
-
-      typeDeclaration.setName(unit.getAST().newSimpleName(type.getName()));
-      if (typeDeclaration instanceof TypeDeclaration)
-      {
-         TypeDeclaration td = (TypeDeclaration) typeDeclaration;
-         for (Type arg : type.getTypeArguments())
-         {
-            TypeParameter typeParameter = unit.getAST().newTypeParameter();
-            typeParameter.setName(unit.getAST().newSimpleName(arg.getName()));
-            td.typeParameters().add(typeParameter);
-         }
-      }
-      return updateTypeNames(name);
-   }
-
-   @Override
-   public String getCanonicalName()
-   {
-      String result = getName();
-
-      JavaType<?> enclosingTypeLocal = this;
-      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
-      {
-         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
-         result = enclosingTypeLocal.getName() + "." + result;
-      }
-
-      if (!Strings.isNullOrEmpty(getPackage()))
-         result = getPackage() + "." + result;
-
-      return result;
-   }
-
-   /**
-    * Call-back to allow updating of any necessary internal names with the given name.
-    */
-   protected abstract O updateTypeNames(String name);
-
-   @Override
-   public String getQualifiedName()
-   {
-      String result = getName();
-
-      JavaType<?> enclosingTypeLocal = this;
-      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
-      {
-         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
-         result = enclosingTypeLocal.getName() + "$" + result;
-      }
-
-      if (!Strings.isNullOrEmpty(getPackage()))
-         result = getPackage() + "." + result;
-
-      return result;
-   }
-
-   /*
-    * Package modifiers
-    */
-   @Override
-   public String getPackage()
-   {
-      PackageDeclaration pkg = unit.getPackage();
-      if (pkg != null)
-      {
-         return pkg.getName().getFullyQualifiedName();
-      }
-      else
-      {
-         return null;
-      }
-   }
-
-   @Override
-   public O setPackage(final String name)
-   {
-      if (unit.getPackage() == null)
-      {
-         unit.setPackage(unit.getAST().newPackageDeclaration());
-      }
-      unit.getPackage().setName(unit.getAST().newName(name));
-      return (O) this;
-   }
-
-   @Override
-   public O setDefaultPackage()
-   {
-      unit.setPackage(null);
-      return (O) this;
-   }
-
-   @Override
-   public boolean isDefaultPackage()
-   {
-      return unit.getPackage() == null;
-   }
-
-   /*
-    * Visibility modifiers
-    */
-   @Override
-   public boolean isPackagePrivate()
-   {
-      return !isPublic() && !isPrivate() && !isProtected();
-   }
-
-   @Override
-   public O setPackagePrivate()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      return (O) this;
-   }
-
-   @Override
-   public boolean isPublic()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
-   }
-
-   @Override
-   public O setPublic()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
-      return (O) this;
-   }
-
-   @Override
-   public boolean isPrivate()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
-   }
-
-   @Override
-   public O setPrivate()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
-      return (O) this;
-   }
-
-   @Override
-   public boolean isProtected()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
-   }
-
-   @Override
-   public O setProtected()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
-      return (O) this;
-   }
-
-   @Override
-   public Visibility getVisibility()
-   {
-      return Visibility.getFrom(this);
-   }
-
-   @Override
-   public O setVisibility(final Visibility scope)
-   {
-      return (O) Visibility.set(this, scope);
-   }
-
-   /*
-    * Non-manipulation methods.
-    */
-   /**
-    * Return this {@link JavaType} file as a String
-    */
-   @Override
-   public String toString()
-   {
-      return Formatter.format(toUnformattedString());
-   }
-
-   @Override
-   public String toUnformattedString()
-   {
-      Document documentLocal = new Document(this.document.get());
-
-      try
-      {
-         @SuppressWarnings("rawtypes")
-         Map options = JavaCore.getOptions();
-         options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
-         options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
-         TextEdit edit = unit.rewrite(documentLocal, options);
-         edit.apply(documentLocal);
-      }
-      catch (Exception e)
-      {
-         throw new ParserException("Could not modify source: " + unit.toString(), e);
-      }
-
-      return documentLocal.get();
-   }
-
-   @Override
-   public Object getInternal()
-   {
-      return unit;
-   }
-
-   @Override
-   public O getOrigin()
-   {
-      return (O) this;
-   }
-
-   @Override
-   public int hashCode()
-   {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((body == null) ? 0 : body.hashCode());
-      result = prime * result + ((document == null) ? 0 : document.hashCode());
-      result = prime * result + ((enclosingType == null || enclosingType == this) ? 0 : enclosingType.hashCode());
-      result = prime * result + ((unit == null) ? 0 : unit.hashCode());
-      return result;
-   }
-
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
-      if (body == null)
-      {
-         if (other.body != null)
-            return false;
-      }
-      else if (!body.equals(other.body))
-         return false;
-      if (document == null)
-      {
-         if (other.document != null)
-            return false;
-      }
-      else if (!document.equals(other.document))
-         return false;
-      if (enclosingType == null)
-      {
-         if (other.enclosingType != null)
-            return false;
-      }
-      else if (!enclosingType.equals(other.enclosingType))
-         return false;
-      if (unit == null)
-      {
-         if (other.unit != null)
-            return false;
-      }
-      else if (!unit.equals(other.unit))
-         return false;
-      return true;
-   }
-
-   @Override
-   public List<SyntaxError> getSyntaxErrors()
-   {
-      List<SyntaxError> result = new ArrayList<SyntaxError>();
-
-      IProblem[] problems = unit.getProblems();
-      if (problems != null)
-      {
-         for (IProblem problem : problems)
-         {
-            result.add(new SyntaxErrorImpl(this, problem));
-         }
-      }
-      return result;
-   }
-
-   @Override
-   public boolean hasSyntaxErrors()
-   {
-      return !getSyntaxErrors().isEmpty();
-   }
-
-   @Override
-   public boolean isClass()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return (declaration instanceof TypeDeclaration)
-               && !((TypeDeclaration) declaration).isInterface();
-
-   }
-
-   @Override
-   public boolean isEnum()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return declaration instanceof EnumDeclaration;
-   }
-
-   @Override
-   public boolean isInterface()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return (declaration instanceof TypeDeclaration)
-               && ((TypeDeclaration) declaration).isInterface();
-   }
-
-   @Override
-   public boolean isAnnotation()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return declaration instanceof AnnotationTypeDeclaration;
    }
 
    /*
@@ -808,7 +60,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       List<AbstractTypeDeclaration> declarations = getNestedDeclarations(body);
 
-      List<JavaSource<?>> result = new ArrayList<JavaSource<?>>();
+      List<JavaSource<?>> result = new ArrayList<>();
       for (AbstractTypeDeclaration declaration : declarations)
       {
          result.add(JavaParserImpl.getJavaSource(this, document, unit, declaration));
@@ -875,7 +127,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       if (type instanceof AbstractJavaSource)
       {
-         List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+         List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
          BodyDeclaration nestedBody = ((AbstractJavaSource<?>) type).body;
          bodyDeclarations.add(ASTNode.copySubtree(unit.getAST(), nestedBody));
       }
@@ -892,7 +144,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       if (type instanceof AbstractJavaSource)
       {
          BodyDeclaration bodyDeclaration = ((AbstractJavaSource<?>) type).body;
-         List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+         List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
          bodyDeclarations.remove(bodyDeclaration);
       }
       return (O) this;
@@ -913,34 +165,9 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    }
 
    @Override
-   public JavaDocSource<O> getJavaDoc()
-   {
-      Javadoc javadoc = body.getJavadoc();
-      if (javadoc == null)
-      {
-         javadoc = body.getAST().newJavadoc();
-         body.setJavadoc(javadoc);
-      }
-      return new JavaDocImpl<O>((O) this, javadoc);
-   }
-
-   @Override
-   public O removeJavaDoc()
-   {
-      body.setJavadoc(null);
-      return (O) this;
-   }
-
-   @Override
-   public boolean hasJavaDoc()
-   {
-      return body.getJavadoc() != null;
-   }
-
-   @Override
    public boolean isStatic()
    {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
    }
 
    @Override
@@ -948,11 +175,11 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       if (_static)
       {
-         modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+         modifiers.addModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
       }
       else
       {
-         modifiers.removeModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+         modifiers.removeModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
       }
       return (O) this;
    }
@@ -963,7 +190,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       body.accept(typeDeclarationFinder);
       List<AbstractTypeDeclaration> declarations = typeDeclarationFinder.getTypeDeclarations();
 
-      List<AbstractTypeDeclaration> result = new ArrayList<AbstractTypeDeclaration>(declarations);
+      List<AbstractTypeDeclaration> result = new ArrayList<>(declarations);
       if (!declarations.isEmpty())
       {
          // We don't want to return the current class' declaration.
@@ -978,25 +205,88 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    }
 
    @Override
-   public Import addImport(final Type<?> type)
+   protected AbstractTypeDeclaration getDeclaration()
    {
-      Import imprt;
-      if (requiresImport(type.getQualifiedName()))
-      {
-         imprt = addImport(type.getQualifiedName());
-      }
-      else
-      {
-         imprt = getImport(type.getQualifiedName());
-      }
-      for (Type<?> arg : type.getTypeArguments())
-      {
-         if (!arg.isWildcard() && arg.isQualified())
-         {
-            addImport(arg);
-         }
-      }
-      return imprt;
+      if (body instanceof AbstractTypeDeclaration)
+         return (AbstractTypeDeclaration) body;
+      throw new ParserException("Source body was not of the expected type.");
    }
 
+   @Override
+   public int hashCode()
+   {
+      return super.hashCode() + Objects.hash(body);
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
+      if (body == null)
+      {
+         if (other.body != null)
+            return false;
+      }
+      else if (!body.equals(other.body))
+         return false;
+      return super.equals(obj);
+   }
+
+   @SuppressWarnings("rawtypes")
+   @Override
+   public O setName(final String name)
+   {
+      AbstractTypeDeclaration typeDeclaration = getDeclaration();
+      TypeImpl<O> type = new TypeImpl(this, null, name);
+
+      typeDeclaration.setName(unit.getAST().newSimpleName(type.getName()));
+      if (typeDeclaration instanceof TypeDeclaration)
+      {
+         TypeDeclaration td = (TypeDeclaration) typeDeclaration;
+         for (Type<?> arg : type.getTypeArguments())
+         {
+            TypeParameter typeParameter = unit.getAST().newTypeParameter();
+            typeParameter.setName(unit.getAST().newSimpleName(arg.getName()));
+            td.typeParameters().add(typeParameter);
+         }
+      }
+      return updateTypeNames(name);
+   }
+
+   @Override
+   public String getName()
+   {
+      return getDeclaration().getName().getIdentifier();
+   }
+
+   @Override
+   public JavaDocSource<O> getJavaDoc()
+   {
+      Javadoc javadoc = body.getJavadoc();
+      if (javadoc == null)
+      {
+         javadoc = body.getAST().newJavadoc();
+         body.setJavadoc(javadoc);
+      }
+      return new JavaDocImpl<>((O) this, javadoc);
+   }
+
+   @Override
+   public O removeJavaDoc()
+   {
+      body.setJavadoc(null);
+      return (O) this;
+   }
+
+   @Override
+   public boolean hasJavaDoc()
+   {
+      return body.getJavadoc() != null;
+   }
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -7,48 +7,799 @@
 package org.jboss.forge.roaster.model.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeParameter;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.TextEdit;
 import org.jboss.forge.roaster.ParserException;
 import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.Annotation;
 import org.jboss.forge.roaster.model.JavaType;
+import org.jboss.forge.roaster.model.SyntaxError;
 import org.jboss.forge.roaster.model.Type;
+import org.jboss.forge.roaster.model.Visibility;
+import org.jboss.forge.roaster.model.ast.AnnotationAccessor;
 import org.jboss.forge.roaster.model.ast.ModifierAccessor;
 import org.jboss.forge.roaster.model.ast.TypeDeclarationFinderVisitor;
+import org.jboss.forge.roaster.model.source.AnnotationSource;
+import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaDocSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.StaticCapableSource;
 import org.jboss.forge.roaster.model.source.TypeHolderSource;
+import org.jboss.forge.roaster.model.util.Formatter;
 import org.jboss.forge.roaster.model.util.Strings;
+import org.jboss.forge.roaster.model.util.Types;
 import org.jboss.forge.roaster.spi.JavaParserImpl;
+import org.jboss.forge.roaster.spi.WildcardImportResolver;
 
 /**
- * Represents a Java Source File which allow types
+ * Represents a Java Source File
  *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 @SuppressWarnings("unchecked")
-
-public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSourceImpl<O> implements
-         TypeHolderSource<O>, StaticCapableSource<O>
+public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
+         JavaSource<O>, TypeHolderSource<O>, StaticCapableSource<O>
 {
-   protected final BodyDeclaration body;
+   private final AnnotationAccessor<O, O> annotations = new AnnotationAccessor<>();
    private final ModifierAccessor modifiers = new ModifierAccessor();
+
+   protected final Document document;
+   protected final CompilationUnit unit;
+   protected final BodyDeclaration body;
+   protected final JavaSource<?> enclosingType;
+
+   private static List<WildcardImportResolver> resolvers;
 
    protected AbstractJavaSource(JavaSource<?> enclosingType, final Document document, final CompilationUnit unit,
             BodyDeclaration body)
    {
-      super(enclosingType, document, unit);
+      this.enclosingType = enclosingType == null ? this : enclosingType;
+      this.document = document;
+      this.unit = unit;
       this.body = body;
+   }
+
+   @Override
+   public JavaSource<?> getEnclosingType()
+   {
+      return enclosingType;
+   }
+
+   /*
+    * Annotation modifiers
+    */
+   @Override
+   public AnnotationSource<O> addAnnotation()
+   {
+      return annotations.addAnnotation(this, getBodyDeclaration());
+   }
+
+   @Override
+   public AnnotationSource<O> addAnnotation(final Class<? extends java.lang.annotation.Annotation> clazz)
+   {
+      return annotations.addAnnotation(this, getBodyDeclaration(), clazz.getName());
+   }
+
+   @Override
+   public AnnotationSource<O> addAnnotation(final String className)
+   {
+      return annotations.addAnnotation(this, getBodyDeclaration(), className);
+   }
+
+   @Override
+   public List<AnnotationSource<O>> getAnnotations()
+   {
+      return annotations.getAnnotations(this, getBodyDeclaration());
+   }
+
+   @Override
+   public boolean hasAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
+   {
+      return annotations.hasAnnotation(this, getBodyDeclaration(), type.getName());
+   }
+
+   @Override
+   public boolean hasAnnotation(final String type)
+   {
+      return annotations.hasAnnotation(this, getBodyDeclaration(), type);
+   }
+
+   @Override
+   public O removeAnnotation(final Annotation<O> annotation)
+   {
+      return (O) annotations.removeAnnotation(this, getBodyDeclaration(), annotation);
+   }
+
+   @Override
+   public void removeAllAnnotations()
+   {
+      annotations.removeAllAnnotations(getBodyDeclaration());
+   }
+
+   @Override
+   public AnnotationSource<O> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
+   {
+      return annotations.getAnnotation(this, getBodyDeclaration(), type);
+   }
+
+   @Override
+   public AnnotationSource<O> getAnnotation(final String type)
+   {
+      return annotations.getAnnotation(this, getBodyDeclaration(), type);
+   }
+
+   /*
+    * Import modifiers
+    */
+
+   @Override
+   public Import addImport(final Class<?> type)
+   {
+      return addImport(type.getCanonicalName());
+   }
+
+   @Override
+   public <T extends JavaType<?>> Import addImport(final T type)
+   {
+      String qualifiedName = type.getQualifiedName();
+      return this.addImport(qualifiedName);
+   }
+
+   @Override
+   public Import addImport(final Import imprt)
+   {
+      return addImport(imprt.getQualifiedName()).setStatic(imprt.isStatic());
+   }
+
+   @Override
+   public Import addImport(final String className)
+   {
+      String strippedClassName = Types.stripGenerics(Types.stripArray(className));
+
+      if (Types.isGeneric(className))
+      {
+         for (String genericPart : Types.splitGenerics(className))
+         {
+            if (Types.isQualified(genericPart))
+               addImport(genericPart);
+         }
+      }
+
+      Import imprt;
+      if (!hasImport(strippedClassName) && validImport(strippedClassName))
+      {
+         imprt = new ImportImpl(this).setName(strippedClassName);
+         unit.imports().add(imprt.getInternal());
+      }
+      else if (hasImport(strippedClassName))
+      {
+         imprt = getImport(strippedClassName);
+      }
+      else
+      {
+         imprt = null;
+      }
+      return imprt;
+   }
+
+   @Override
+   public Import getImport(final String className)
+   {
+      for (Import imprt : getImports())
+      {
+         if (imprt.getQualifiedName().equals(className) || imprt.getSimpleName().equals(className))
+         {
+            return imprt;
+         }
+      }
+      return null;
+   }
+
+   @Override
+   public Import getImport(final Class<?> type)
+   {
+      return getImport(type.getName());
+   }
+
+   @Override
+   public <T extends JavaType<?>> Import getImport(final T type)
+   {
+      return getImport(type.getQualifiedName());
+   }
+
+   @Override
+   public Import getImport(final Import imprt)
+   {
+      return getImport(imprt.getQualifiedName());
+   }
+
+   @Override
+   public List<Import> getImports()
+   {
+      List<Import> results = new ArrayList<>();
+
+      for (ImportDeclaration i : (List<ImportDeclaration>) unit.imports())
+      {
+         results.add(new ImportImpl(this, i));
+      }
+
+      return Collections.unmodifiableList(results);
+   }
+
+   @Override
+   public boolean hasImport(final Class<?> type)
+   {
+      return hasImport(type.getName());
+   }
+
+   @Override
+   public <T extends JavaType<T>> boolean hasImport(final T type)
+   {
+      return hasImport(type.getQualifiedName());
+   }
+
+   @Override
+   public boolean hasImport(final Import imprt)
+   {
+      return hasImport(imprt.getQualifiedName());
+   }
+
+   @Override
+   public boolean hasImport(final String type)
+   {
+      String resultType = type;
+      if (Types.isArray(type))
+      {
+         resultType = Types.stripArray(type);
+      }
+      if (Types.isGeneric(type))
+      {
+         resultType = Types.stripGenerics(type);
+      }
+      return getImport(resultType) != null;
+   }
+
+   @Override
+   public boolean requiresImport(final Class<?> type)
+   {
+      return requiresImport(type.getName());
+   }
+
+   @Override
+   public boolean requiresImport(final String type)
+   {
+      boolean requiresImport = false;
+      String resultType = type;
+      if (Types.isArray(resultType))
+      {
+         resultType = Types.stripArray(resultType);
+      }
+      if (Types.isGeneric(resultType))
+      {
+         for (String genericPart : Types.splitGenerics(resultType))
+         {
+            requiresImport |= requiresImport(genericPart);
+         }
+         resultType = Types.stripGenerics(resultType);
+      }
+      requiresImport |= !(!validImport(resultType)
+               || hasImport(resultType)
+               || Types.isJavaLang(resultType)
+               || Strings.areEqual(getPackage(), Types.getPackage(resultType)));
+      return requiresImport;
+   }
+
+   @Override
+   public String resolveType(final String type)
+   {
+      String result = type;
+
+      // Strip away any characters that might hinder the type matching process
+      if (Types.isArray(result))
+      {
+         result = Types.stripArray(result);
+      }
+
+      if (Types.isGeneric(result))
+      {
+         result = Types.stripGenerics(result);
+      }
+
+      // primitive types don't need a import -> direct return
+      if (Types.isPrimitive(result))
+      {
+         return result;
+      }
+
+      // qualified names don't need to be resolved
+      if (Types.isQualified(result))
+      {
+         return result;
+      }
+
+      // java lang types are implicitly imported and we don't allow a duplicate simple name in another package
+      if (Types.isJavaLang(result))
+      {
+         return "java.lang." + result;
+      }
+
+      // Check for an existing direct import
+      Import directImport = getImport(result);
+      if (directImport != null)
+      {
+         return directImport.getQualifiedName();
+      }
+
+      List<Import> imports = getImports(); // fetch imports only once
+
+      // if we have no imports and no fqn name the following doesn't need to be executed
+      if (!imports.isEmpty())
+      {
+         // if we have only one wildcard import we can use this
+         List<Import> wildcardImports = imports.stream().filter(Import::isWildcard).collect(Collectors.toList());
+         if (wildcardImports.size() == 1)
+         {
+            return wildcardImports.get(0).getPackage() + "." + result;
+         }
+
+         // If we didn't match any imports directly, we might have a wild-card/on-demand import.
+         for (Import imprt : imports)
+         {
+            if (imprt.isWildcard())
+            {
+               // TODO warn if no wild-card resolvers are configured
+               // TODO Test wild-card/on-demand import resolving
+               for (WildcardImportResolver r : getImportResolvers())
+               {
+                  result = r.resolve(this, result);
+                  if (Types.isQualified(result))
+                     return result;
+               }
+            }
+         }
+      }
+
+      // Nothing matched since here, so try to resolve it with the current package
+      if (getPackage() != null)
+      {
+         return getPackage() + "." + result;
+      }
+
+      return result;
+   }
+
+   private List<WildcardImportResolver> getImportResolvers()
+   {
+      if (resolvers == null)
+      {
+         resolvers = new ArrayList<>();
+         for (WildcardImportResolver r : ServiceLoader.load(WildcardImportResolver.class, getClass().getClassLoader()))
+         {
+            resolvers.add(r);
+         }
+      }
+      if (resolvers.isEmpty())
+      {
+         throw new IllegalStateException("No instances of [" + WildcardImportResolver.class.getName()
+                  + "] were found on the classpath.");
+      }
+      return resolvers;
+   }
+
+   private boolean validImport(final String type)
+   {
+      String className = Types.toSimpleName(type);
+      // check if this class name is equal to the class to import
+      if (className.equals(getName()))
+      {
+         return false;
+      }
+      // check if any import has the same class name
+      for (final Import imprt : getImports())
+      {
+         String importClassName = imprt.getSimpleName();
+         if (importClassName.equals(className))
+         {
+            return false;
+         }
+      }
+      return !Strings.isNullOrEmpty(type) && !Types.isPrimitive(type) && !Strings.isNullOrEmpty(Types.getPackage(type));
+   }
+
+   @Override
+   public O removeImport(final String name)
+   {
+      for (Import i : getImports())
+      {
+         if (i.getQualifiedName().equals(name))
+         {
+            removeImport(i);
+            break;
+         }
+      }
+      return (O) this;
+   }
+
+   @Override
+   public O removeImport(final Class<?> clazz)
+   {
+      return removeImport(clazz.getName());
+   }
+
+   @Override
+   public <T extends JavaType<?>> O removeImport(final T type)
+   {
+      return removeImport(type.getQualifiedName());
+   }
+
+   @Override
+   public O removeImport(final Import imprt)
+   {
+      Object internal = imprt.getInternal();
+      if (unit.imports().contains(internal))
+      {
+         unit.imports().remove(internal);
+      }
+      return (O) this;
+   }
+
+   protected AbstractTypeDeclaration getBodyDeclaration()
+   {
+      if (body instanceof AbstractTypeDeclaration)
+         return (AbstractTypeDeclaration) body;
+      throw new ParserException("Source body was not of the expected type.");
+   }
+
+   /*
+    * Name modifiers
+    */
+   @Override
+   public String getName()
+   {
+      return getBodyDeclaration().getName().getIdentifier();
+   }
+
+   @SuppressWarnings("rawtypes")
+   @Override
+   public O setName(final String name)
+   {
+      AbstractTypeDeclaration typeDeclaration = getBodyDeclaration();
+      TypeImpl<O> type = new TypeImpl(this, null, name);
+
+      typeDeclaration.setName(unit.getAST().newSimpleName(type.getName()));
+      if (typeDeclaration instanceof TypeDeclaration)
+      {
+         TypeDeclaration td = (TypeDeclaration) typeDeclaration;
+         for (Type arg : type.getTypeArguments())
+         {
+            TypeParameter typeParameter = unit.getAST().newTypeParameter();
+            typeParameter.setName(unit.getAST().newSimpleName(arg.getName()));
+            td.typeParameters().add(typeParameter);
+         }
+      }
+      return updateTypeNames(name);
+   }
+
+   @Override
+   public String getCanonicalName()
+   {
+      String result = getName();
+
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
+      {
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
+         result = enclosingTypeLocal.getName() + "." + result;
+      }
+
+      if (!Strings.isNullOrEmpty(getPackage()))
+         result = getPackage() + "." + result;
+
+      return result;
+   }
+
+   /**
+    * Call-back to allow updating of any necessary internal names with the given name.
+    */
+   protected abstract O updateTypeNames(String name);
+
+   @Override
+   public String getQualifiedName()
+   {
+      String result = getName();
+
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
+      {
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
+         result = enclosingTypeLocal.getName() + "$" + result;
+      }
+
+      if (!Strings.isNullOrEmpty(getPackage()))
+         result = getPackage() + "." + result;
+
+      return result;
+   }
+
+   /*
+    * Package modifiers
+    */
+   @Override
+   public String getPackage()
+   {
+      PackageDeclaration pkg = unit.getPackage();
+      if (pkg != null)
+      {
+         return pkg.getName().getFullyQualifiedName();
+      }
+      return null;
+   }
+
+   @Override
+   public O setPackage(final String name)
+   {
+      if (unit.getPackage() == null)
+      {
+         unit.setPackage(unit.getAST().newPackageDeclaration());
+      }
+      unit.getPackage().setName(unit.getAST().newName(name));
+      return (O) this;
+   }
+
+   @Override
+   public O setDefaultPackage()
+   {
+      unit.setPackage(null);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isDefaultPackage()
+   {
+      return unit.getPackage() == null;
+   }
+
+   /*
+    * Visibility modifiers
+    */
+   @Override
+   public boolean isPackagePrivate()
+   {
+      return !isPublic() && !isPrivate() && !isProtected();
+   }
+
+   @Override
+   public O setPackagePrivate()
+   {
+      modifiers.clearVisibility(getBodyDeclaration());
+      return (O) this;
+   }
+
+   @Override
+   public boolean isPublic()
+   {
+      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
+   }
+
+   @Override
+   public O setPublic()
+   {
+      modifiers.clearVisibility(getBodyDeclaration());
+      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isPrivate()
+   {
+      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
+   }
+
+   @Override
+   public O setPrivate()
+   {
+      modifiers.clearVisibility(getBodyDeclaration());
+      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isProtected()
+   {
+      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
+   }
+
+   @Override
+   public O setProtected()
+   {
+      modifiers.clearVisibility(getBodyDeclaration());
+      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
+      return (O) this;
+   }
+
+   @Override
+   public Visibility getVisibility()
+   {
+      return Visibility.getFrom(this);
+   }
+
+   @Override
+   public O setVisibility(final Visibility scope)
+   {
+      return (O) Visibility.set(this, scope);
+   }
+
+   /*
+    * Non-manipulation methods.
+    */
+   /**
+    * Return this {@link JavaType} file as a String
+    */
+   @Override
+   public String toString()
+   {
+      return Formatter.format(toUnformattedString());
+   }
+
+   @Override
+   public String toUnformattedString()
+   {
+      Document documentLocal = new Document(this.document.get());
+
+      try
+      {
+         @SuppressWarnings("rawtypes")
+         Map options = JavaCore.getOptions();
+         options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
+         options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
+         TextEdit edit = unit.rewrite(documentLocal, options);
+         edit.apply(documentLocal);
+      }
+      catch (Exception e)
+      {
+         throw new ParserException("Could not modify source: " + unit.toString(), e);
+      }
+
+      return documentLocal.get();
+   }
+
+   @Override
+   public Object getInternal()
+   {
+      return unit;
+   }
+
+   @Override
+   public O getOrigin()
+   {
+      return (O) this;
+   }
+
+   @Override
+   public int hashCode()
+   {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((body == null) ? 0 : body.hashCode());
+      result = prime * result + ((document == null) ? 0 : document.hashCode());
+      result = prime * result + ((enclosingType == null || enclosingType == this) ? 0 : enclosingType.hashCode());
+      result = prime * result + ((unit == null) ? 0 : unit.hashCode());
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
+      if (body == null)
+      {
+         if (other.body != null)
+            return false;
+      }
+      else if (!body.equals(other.body))
+         return false;
+      if (document == null)
+      {
+         if (other.document != null)
+            return false;
+      }
+      else if (!document.equals(other.document))
+         return false;
+      if (enclosingType == null)
+      {
+         if (other.enclosingType != null)
+            return false;
+      }
+      else if (!enclosingType.equals(other.enclosingType))
+         return false;
+      if (unit == null)
+      {
+         if (other.unit != null)
+            return false;
+      }
+      else if (!unit.equals(other.unit))
+         return false;
+      return true;
+   }
+
+   @Override
+   public List<SyntaxError> getSyntaxErrors()
+   {
+      List<SyntaxError> result = new ArrayList<>();
+
+      IProblem[] problems = unit.getProblems();
+      if (problems != null)
+      {
+         for (IProblem problem : problems)
+         {
+            result.add(new SyntaxErrorImpl(this, problem));
+         }
+      }
+      return result;
+   }
+
+   @Override
+   public boolean hasSyntaxErrors()
+   {
+      return !getSyntaxErrors().isEmpty();
+   }
+
+   @Override
+   public boolean isClass()
+   {
+      AbstractTypeDeclaration declaration = getBodyDeclaration();
+      return (declaration instanceof TypeDeclaration)
+               && !((TypeDeclaration) declaration).isInterface();
+
+   }
+
+   @Override
+   public boolean isEnum()
+   {
+      AbstractTypeDeclaration declaration = getBodyDeclaration();
+      return declaration instanceof EnumDeclaration;
+   }
+
+   @Override
+   public boolean isInterface()
+   {
+      AbstractTypeDeclaration declaration = getBodyDeclaration();
+      return (declaration instanceof TypeDeclaration)
+               && ((TypeDeclaration) declaration).isInterface();
+   }
+
+   @Override
+   public boolean isAnnotation()
+   {
+      AbstractTypeDeclaration declaration = getBodyDeclaration();
+      return declaration instanceof AnnotationTypeDeclaration;
    }
 
    /*
@@ -127,7 +878,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSo
    {
       if (type instanceof AbstractJavaSource)
       {
-         List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
+         List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
          BodyDeclaration nestedBody = ((AbstractJavaSource<?>) type).body;
          bodyDeclarations.add(ASTNode.copySubtree(unit.getAST(), nestedBody));
       }
@@ -144,7 +895,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSo
       if (type instanceof AbstractJavaSource)
       {
          BodyDeclaration bodyDeclaration = ((AbstractJavaSource<?>) type).body;
-         List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
+         List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
          bodyDeclarations.remove(bodyDeclaration);
       }
       return (O) this;
@@ -162,107 +913,6 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSo
    {
       JavaSource<?> nestedType = Roaster.parse(JavaSource.class, declaration);
       return (NESTED_TYPE) addNestedType(nestedType);
-   }
-
-   @Override
-   public boolean isStatic()
-   {
-      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
-   }
-
-   @Override
-   public O setStatic(boolean _static)
-   {
-      if (_static)
-      {
-         modifiers.addModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
-      }
-      else
-      {
-         modifiers.removeModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
-      }
-      return (O) this;
-   }
-
-   private List<AbstractTypeDeclaration> getNestedDeclarations(BodyDeclaration body)
-   {
-      TypeDeclarationFinderVisitor typeDeclarationFinder = new TypeDeclarationFinderVisitor();
-      body.accept(typeDeclarationFinder);
-      List<AbstractTypeDeclaration> declarations = typeDeclarationFinder.getTypeDeclarations();
-
-      List<AbstractTypeDeclaration> result = new ArrayList<>(declarations);
-      if (!declarations.isEmpty())
-      {
-         // We don't want to return the current class' declaration.
-         result.remove(declarations.remove(0));
-         for (AbstractTypeDeclaration declaration : declarations)
-         {
-            result.removeAll(getNestedDeclarations(declaration));
-         }
-      }
-
-      return result;
-   }
-
-   @Override
-   protected AbstractTypeDeclaration getDeclaration()
-   {
-      if (body instanceof AbstractTypeDeclaration)
-         return (AbstractTypeDeclaration) body;
-      throw new ParserException("Source body was not of the expected type.");
-   }
-
-   @Override
-   public int hashCode()
-   {
-      return super.hashCode() + Objects.hash(body);
-   }
-
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
-      if (body == null)
-      {
-         if (other.body != null)
-            return false;
-      }
-      else if (!body.equals(other.body))
-         return false;
-      return super.equals(obj);
-   }
-
-   @SuppressWarnings("rawtypes")
-   @Override
-   public O setName(final String name)
-   {
-      AbstractTypeDeclaration typeDeclaration = getDeclaration();
-      TypeImpl<O> type = new TypeImpl(this, null, name);
-
-      typeDeclaration.setName(unit.getAST().newSimpleName(type.getName()));
-      if (typeDeclaration instanceof TypeDeclaration)
-      {
-         TypeDeclaration td = (TypeDeclaration) typeDeclaration;
-         for (Type<?> arg : type.getTypeArguments())
-         {
-            TypeParameter typeParameter = unit.getAST().newTypeParameter();
-            typeParameter.setName(unit.getAST().newSimpleName(arg.getName()));
-            td.typeParameters().add(typeParameter);
-         }
-      }
-      return updateTypeNames(name);
-   }
-
-   @Override
-   public String getName()
-   {
-      return getDeclaration().getName().getIdentifier();
    }
 
    @Override
@@ -289,4 +939,67 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSo
    {
       return body.getJavadoc() != null;
    }
+
+   @Override
+   public boolean isStatic()
+   {
+      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+   }
+
+   @Override
+   public O setStatic(boolean _static)
+   {
+      if (_static)
+      {
+         modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+      }
+      else
+      {
+         modifiers.removeModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+      }
+      return (O) this;
+   }
+
+   private List<AbstractTypeDeclaration> getNestedDeclarations(BodyDeclaration body)
+   {
+      TypeDeclarationFinderVisitor typeDeclarationFinder = new TypeDeclarationFinderVisitor();
+      body.accept(typeDeclarationFinder);
+      List<AbstractTypeDeclaration> declarations = typeDeclarationFinder.getTypeDeclarations();
+
+      List<AbstractTypeDeclaration> result = new ArrayList<>(declarations);
+      if (!declarations.isEmpty())
+      {
+         // We don't want to return the current class' declaration.
+         result.remove(declarations.remove(0));
+         for (AbstractTypeDeclaration declaration : declarations)
+         {
+            result.removeAll(getNestedDeclarations(declaration));
+         }
+      }
+
+      return result;
+   }
+
+   @Override
+   public Import addImport(final Type<?> type)
+   {
+      Import imprt;
+      if (requiresImport(type.getQualifiedName()))
+      {
+         imprt = addImport(type.getQualifiedName());
+      }
+      else
+      {
+         imprt = getImport(type.getQualifiedName());
+      }
+      for (Type<?> arg : type.getTypeArguments())
+      {
+         if (!arg.isWildcard() && arg.isQualified())
+         {
+            addImport(arg);
+         }
+      }
+      return imprt;
+   }
+
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -7,799 +7,48 @@
 package org.jboss.forge.roaster.model.impl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.compiler.IProblem;
+import java.util.Objects;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
-import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.EnumDeclaration;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
-import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeParameter;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jface.text.Document;
-import org.eclipse.text.edits.TextEdit;
 import org.jboss.forge.roaster.ParserException;
 import org.jboss.forge.roaster.Roaster;
-import org.jboss.forge.roaster.model.Annotation;
 import org.jboss.forge.roaster.model.JavaType;
-import org.jboss.forge.roaster.model.SyntaxError;
 import org.jboss.forge.roaster.model.Type;
-import org.jboss.forge.roaster.model.Visibility;
-import org.jboss.forge.roaster.model.ast.AnnotationAccessor;
 import org.jboss.forge.roaster.model.ast.ModifierAccessor;
 import org.jboss.forge.roaster.model.ast.TypeDeclarationFinderVisitor;
-import org.jboss.forge.roaster.model.source.AnnotationSource;
-import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaDocSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.StaticCapableSource;
 import org.jboss.forge.roaster.model.source.TypeHolderSource;
-import org.jboss.forge.roaster.model.util.Formatter;
 import org.jboss.forge.roaster.model.util.Strings;
-import org.jboss.forge.roaster.model.util.Types;
 import org.jboss.forge.roaster.spi.JavaParserImpl;
-import org.jboss.forge.roaster.spi.WildcardImportResolver;
 
 /**
- * Represents a Java Source File
+ * Represents a Java Source File which allow types
  *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 @SuppressWarnings("unchecked")
-public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
-         JavaSource<O>, TypeHolderSource<O>, StaticCapableSource<O>
+
+public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSourceImpl<O> implements
+         TypeHolderSource<O>, StaticCapableSource<O>
 {
-   private final AnnotationAccessor<O, O> annotations = new AnnotationAccessor<>();
-   private final ModifierAccessor modifiers = new ModifierAccessor();
-
-   protected final Document document;
-   protected final CompilationUnit unit;
    protected final BodyDeclaration body;
-   protected final JavaSource<?> enclosingType;
-
-   private static List<WildcardImportResolver> resolvers;
+   private final ModifierAccessor modifiers = new ModifierAccessor();
 
    protected AbstractJavaSource(JavaSource<?> enclosingType, final Document document, final CompilationUnit unit,
             BodyDeclaration body)
    {
-      this.enclosingType = enclosingType == null ? this : enclosingType;
-      this.document = document;
-      this.unit = unit;
+      super(enclosingType, document, unit);
       this.body = body;
-   }
-
-   @Override
-   public JavaSource<?> getEnclosingType()
-   {
-      return enclosingType;
-   }
-
-   /*
-    * Annotation modifiers
-    */
-   @Override
-   public AnnotationSource<O> addAnnotation()
-   {
-      return annotations.addAnnotation(this, getBodyDeclaration());
-   }
-
-   @Override
-   public AnnotationSource<O> addAnnotation(final Class<? extends java.lang.annotation.Annotation> clazz)
-   {
-      return annotations.addAnnotation(this, getBodyDeclaration(), clazz.getName());
-   }
-
-   @Override
-   public AnnotationSource<O> addAnnotation(final String className)
-   {
-      return annotations.addAnnotation(this, getBodyDeclaration(), className);
-   }
-
-   @Override
-   public List<AnnotationSource<O>> getAnnotations()
-   {
-      return annotations.getAnnotations(this, getBodyDeclaration());
-   }
-
-   @Override
-   public boolean hasAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
-   {
-      return annotations.hasAnnotation(this, getBodyDeclaration(), type.getName());
-   }
-
-   @Override
-   public boolean hasAnnotation(final String type)
-   {
-      return annotations.hasAnnotation(this, getBodyDeclaration(), type);
-   }
-
-   @Override
-   public O removeAnnotation(final Annotation<O> annotation)
-   {
-      return (O) annotations.removeAnnotation(this, getBodyDeclaration(), annotation);
-   }
-
-   @Override
-   public void removeAllAnnotations()
-   {
-      annotations.removeAllAnnotations(getBodyDeclaration());
-   }
-
-   @Override
-   public AnnotationSource<O> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
-   {
-      return annotations.getAnnotation(this, getBodyDeclaration(), type);
-   }
-
-   @Override
-   public AnnotationSource<O> getAnnotation(final String type)
-   {
-      return annotations.getAnnotation(this, getBodyDeclaration(), type);
-   }
-
-   /*
-    * Import modifiers
-    */
-
-   @Override
-   public Import addImport(final Class<?> type)
-   {
-      return addImport(type.getCanonicalName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> Import addImport(final T type)
-   {
-      String qualifiedName = type.getQualifiedName();
-      return this.addImport(qualifiedName);
-   }
-
-   @Override
-   public Import addImport(final Import imprt)
-   {
-      return addImport(imprt.getQualifiedName()).setStatic(imprt.isStatic());
-   }
-
-   @Override
-   public Import addImport(final String className)
-   {
-      String strippedClassName = Types.stripGenerics(Types.stripArray(className));
-
-      if (Types.isGeneric(className))
-      {
-         for (String genericPart : Types.splitGenerics(className))
-         {
-            if (Types.isQualified(genericPart))
-               addImport(genericPart);
-         }
-      }
-
-      Import imprt;
-      if (!hasImport(strippedClassName) && validImport(strippedClassName))
-      {
-         imprt = new ImportImpl(this).setName(strippedClassName);
-         unit.imports().add(imprt.getInternal());
-      }
-      else if (hasImport(strippedClassName))
-      {
-         imprt = getImport(strippedClassName);
-      }
-      else
-      {
-         imprt = null;
-      }
-      return imprt;
-   }
-
-   @Override
-   public Import getImport(final String className)
-   {
-      for (Import imprt : getImports())
-      {
-         if (imprt.getQualifiedName().equals(className) || imprt.getSimpleName().equals(className))
-         {
-            return imprt;
-         }
-      }
-      return null;
-   }
-
-   @Override
-   public Import getImport(final Class<?> type)
-   {
-      return getImport(type.getName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> Import getImport(final T type)
-   {
-      return getImport(type.getQualifiedName());
-   }
-
-   @Override
-   public Import getImport(final Import imprt)
-   {
-      return getImport(imprt.getQualifiedName());
-   }
-
-   @Override
-   public List<Import> getImports()
-   {
-      List<Import> results = new ArrayList<>();
-
-      for (ImportDeclaration i : (List<ImportDeclaration>) unit.imports())
-      {
-         results.add(new ImportImpl(this, i));
-      }
-
-      return Collections.unmodifiableList(results);
-   }
-
-   @Override
-   public boolean hasImport(final Class<?> type)
-   {
-      return hasImport(type.getName());
-   }
-
-   @Override
-   public <T extends JavaType<T>> boolean hasImport(final T type)
-   {
-      return hasImport(type.getQualifiedName());
-   }
-
-   @Override
-   public boolean hasImport(final Import imprt)
-   {
-      return hasImport(imprt.getQualifiedName());
-   }
-
-   @Override
-   public boolean hasImport(final String type)
-   {
-      String resultType = type;
-      if (Types.isArray(type))
-      {
-         resultType = Types.stripArray(type);
-      }
-      if (Types.isGeneric(type))
-      {
-         resultType = Types.stripGenerics(type);
-      }
-      return getImport(resultType) != null;
-   }
-
-   @Override
-   public boolean requiresImport(final Class<?> type)
-   {
-      return requiresImport(type.getName());
-   }
-
-   @Override
-   public boolean requiresImport(final String type)
-   {
-      boolean requiresImport = false;
-      String resultType = type;
-      if (Types.isArray(resultType))
-      {
-         resultType = Types.stripArray(resultType);
-      }
-      if (Types.isGeneric(resultType))
-      {
-         for (String genericPart : Types.splitGenerics(resultType))
-         {
-            requiresImport |= requiresImport(genericPart);
-         }
-         resultType = Types.stripGenerics(resultType);
-      }
-      requiresImport |= !(!validImport(resultType)
-               || hasImport(resultType)
-               || Types.isJavaLang(resultType)
-               || Strings.areEqual(getPackage(), Types.getPackage(resultType)));
-      return requiresImport;
-   }
-
-   @Override
-   public String resolveType(final String type)
-   {
-      String result = type;
-
-      // Strip away any characters that might hinder the type matching process
-      if (Types.isArray(result))
-      {
-         result = Types.stripArray(result);
-      }
-
-      if (Types.isGeneric(result))
-      {
-         result = Types.stripGenerics(result);
-      }
-
-      // primitive types don't need a import -> direct return
-      if (Types.isPrimitive(result))
-      {
-         return result;
-      }
-
-      // qualified names don't need to be resolved
-      if (Types.isQualified(result))
-      {
-         return result;
-      }
-
-      // java lang types are implicitly imported and we don't allow a duplicate simple name in another package
-      if (Types.isJavaLang(result))
-      {
-         return "java.lang." + result;
-      }
-
-      // Check for an existing direct import
-      Import directImport = getImport(result);
-      if (directImport != null)
-      {
-         return directImport.getQualifiedName();
-      }
-
-      List<Import> imports = getImports(); // fetch imports only once
-
-      // if we have no imports and no fqn name the following doesn't need to be executed
-      if (!imports.isEmpty())
-      {
-         // if we have only one wildcard import we can use this
-         List<Import> wildcardImports = imports.stream().filter(Import::isWildcard).collect(Collectors.toList());
-         if (wildcardImports.size() == 1)
-         {
-            return wildcardImports.get(0).getPackage() + "." + result;
-         }
-
-         // If we didn't match any imports directly, we might have a wild-card/on-demand import.
-         for (Import imprt : imports)
-         {
-            if (imprt.isWildcard())
-            {
-               // TODO warn if no wild-card resolvers are configured
-               // TODO Test wild-card/on-demand import resolving
-               for (WildcardImportResolver r : getImportResolvers())
-               {
-                  result = r.resolve(this, result);
-                  if (Types.isQualified(result))
-                     return result;
-               }
-            }
-         }
-      }
-
-      // Nothing matched since here, so try to resolve it with the current package
-      if (getPackage() != null)
-      {
-         return getPackage() + "." + result;
-      }
-
-      return result;
-   }
-
-   private List<WildcardImportResolver> getImportResolvers()
-   {
-      if (resolvers == null)
-      {
-         resolvers = new ArrayList<>();
-         for (WildcardImportResolver r : ServiceLoader.load(WildcardImportResolver.class, getClass().getClassLoader()))
-         {
-            resolvers.add(r);
-         }
-      }
-      if (resolvers.isEmpty())
-      {
-         throw new IllegalStateException("No instances of [" + WildcardImportResolver.class.getName()
-                  + "] were found on the classpath.");
-      }
-      return resolvers;
-   }
-
-   private boolean validImport(final String type)
-   {
-      String className = Types.toSimpleName(type);
-      // check if this class name is equal to the class to import
-      if (className.equals(getName()))
-      {
-         return false;
-      }
-      // check if any import has the same class name
-      for (final Import imprt : getImports())
-      {
-         String importClassName = imprt.getSimpleName();
-         if (importClassName.equals(className))
-         {
-            return false;
-         }
-      }
-      return !Strings.isNullOrEmpty(type) && !Types.isPrimitive(type) && !Strings.isNullOrEmpty(Types.getPackage(type));
-   }
-
-   @Override
-   public O removeImport(final String name)
-   {
-      for (Import i : getImports())
-      {
-         if (i.getQualifiedName().equals(name))
-         {
-            removeImport(i);
-            break;
-         }
-      }
-      return (O) this;
-   }
-
-   @Override
-   public O removeImport(final Class<?> clazz)
-   {
-      return removeImport(clazz.getName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> O removeImport(final T type)
-   {
-      return removeImport(type.getQualifiedName());
-   }
-
-   @Override
-   public O removeImport(final Import imprt)
-   {
-      Object internal = imprt.getInternal();
-      if (unit.imports().contains(internal))
-      {
-         unit.imports().remove(internal);
-      }
-      return (O) this;
-   }
-
-   protected AbstractTypeDeclaration getBodyDeclaration()
-   {
-      if (body instanceof AbstractTypeDeclaration)
-         return (AbstractTypeDeclaration) body;
-      throw new ParserException("Source body was not of the expected type.");
-   }
-
-   /*
-    * Name modifiers
-    */
-   @Override
-   public String getName()
-   {
-      return getBodyDeclaration().getName().getIdentifier();
-   }
-
-   @SuppressWarnings("rawtypes")
-   @Override
-   public O setName(final String name)
-   {
-      AbstractTypeDeclaration typeDeclaration = getBodyDeclaration();
-      TypeImpl<O> type = new TypeImpl(this, null, name);
-
-      typeDeclaration.setName(unit.getAST().newSimpleName(type.getName()));
-      if (typeDeclaration instanceof TypeDeclaration)
-      {
-         TypeDeclaration td = (TypeDeclaration) typeDeclaration;
-         for (Type arg : type.getTypeArguments())
-         {
-            TypeParameter typeParameter = unit.getAST().newTypeParameter();
-            typeParameter.setName(unit.getAST().newSimpleName(arg.getName()));
-            td.typeParameters().add(typeParameter);
-         }
-      }
-      return updateTypeNames(name);
-   }
-
-   @Override
-   public String getCanonicalName()
-   {
-      String result = getName();
-
-      JavaType<?> enclosingTypeLocal = this;
-      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
-      {
-         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
-         result = enclosingTypeLocal.getName() + "." + result;
-      }
-
-      if (!Strings.isNullOrEmpty(getPackage()))
-         result = getPackage() + "." + result;
-
-      return result;
-   }
-
-   /**
-    * Call-back to allow updating of any necessary internal names with the given name.
-    */
-   protected abstract O updateTypeNames(String name);
-
-   @Override
-   public String getQualifiedName()
-   {
-      String result = getName();
-
-      JavaType<?> enclosingTypeLocal = this;
-      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
-      {
-         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
-         result = enclosingTypeLocal.getName() + "$" + result;
-      }
-
-      if (!Strings.isNullOrEmpty(getPackage()))
-         result = getPackage() + "." + result;
-
-      return result;
-   }
-
-   /*
-    * Package modifiers
-    */
-   @Override
-   public String getPackage()
-   {
-      PackageDeclaration pkg = unit.getPackage();
-      if (pkg != null)
-      {
-         return pkg.getName().getFullyQualifiedName();
-      }
-      return null;
-   }
-
-   @Override
-   public O setPackage(final String name)
-   {
-      if (unit.getPackage() == null)
-      {
-         unit.setPackage(unit.getAST().newPackageDeclaration());
-      }
-      unit.getPackage().setName(unit.getAST().newName(name));
-      return (O) this;
-   }
-
-   @Override
-   public O setDefaultPackage()
-   {
-      unit.setPackage(null);
-      return (O) this;
-   }
-
-   @Override
-   public boolean isDefaultPackage()
-   {
-      return unit.getPackage() == null;
-   }
-
-   /*
-    * Visibility modifiers
-    */
-   @Override
-   public boolean isPackagePrivate()
-   {
-      return !isPublic() && !isPrivate() && !isProtected();
-   }
-
-   @Override
-   public O setPackagePrivate()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      return (O) this;
-   }
-
-   @Override
-   public boolean isPublic()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
-   }
-
-   @Override
-   public O setPublic()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
-      return (O) this;
-   }
-
-   @Override
-   public boolean isPrivate()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
-   }
-
-   @Override
-   public O setPrivate()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
-      return (O) this;
-   }
-
-   @Override
-   public boolean isProtected()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
-   }
-
-   @Override
-   public O setProtected()
-   {
-      modifiers.clearVisibility(getBodyDeclaration());
-      modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
-      return (O) this;
-   }
-
-   @Override
-   public Visibility getVisibility()
-   {
-      return Visibility.getFrom(this);
-   }
-
-   @Override
-   public O setVisibility(final Visibility scope)
-   {
-      return (O) Visibility.set(this, scope);
-   }
-
-   /*
-    * Non-manipulation methods.
-    */
-   /**
-    * Return this {@link JavaType} file as a String
-    */
-   @Override
-   public String toString()
-   {
-      return Formatter.format(toUnformattedString());
-   }
-
-   @Override
-   public String toUnformattedString()
-   {
-      Document documentLocal = new Document(this.document.get());
-
-      try
-      {
-         @SuppressWarnings("rawtypes")
-         Map options = JavaCore.getOptions();
-         options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
-         options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
-         TextEdit edit = unit.rewrite(documentLocal, options);
-         edit.apply(documentLocal);
-      }
-      catch (Exception e)
-      {
-         throw new ParserException("Could not modify source: " + unit.toString(), e);
-      }
-
-      return documentLocal.get();
-   }
-
-   @Override
-   public Object getInternal()
-   {
-      return unit;
-   }
-
-   @Override
-   public O getOrigin()
-   {
-      return (O) this;
-   }
-
-   @Override
-   public int hashCode()
-   {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((body == null) ? 0 : body.hashCode());
-      result = prime * result + ((document == null) ? 0 : document.hashCode());
-      result = prime * result + ((enclosingType == null || enclosingType == this) ? 0 : enclosingType.hashCode());
-      result = prime * result + ((unit == null) ? 0 : unit.hashCode());
-      return result;
-   }
-
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
-      if (body == null)
-      {
-         if (other.body != null)
-            return false;
-      }
-      else if (!body.equals(other.body))
-         return false;
-      if (document == null)
-      {
-         if (other.document != null)
-            return false;
-      }
-      else if (!document.equals(other.document))
-         return false;
-      if (enclosingType == null)
-      {
-         if (other.enclosingType != null)
-            return false;
-      }
-      else if (!enclosingType.equals(other.enclosingType))
-         return false;
-      if (unit == null)
-      {
-         if (other.unit != null)
-            return false;
-      }
-      else if (!unit.equals(other.unit))
-         return false;
-      return true;
-   }
-
-   @Override
-   public List<SyntaxError> getSyntaxErrors()
-   {
-      List<SyntaxError> result = new ArrayList<>();
-
-      IProblem[] problems = unit.getProblems();
-      if (problems != null)
-      {
-         for (IProblem problem : problems)
-         {
-            result.add(new SyntaxErrorImpl(this, problem));
-         }
-      }
-      return result;
-   }
-
-   @Override
-   public boolean hasSyntaxErrors()
-   {
-      return !getSyntaxErrors().isEmpty();
-   }
-
-   @Override
-   public boolean isClass()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return (declaration instanceof TypeDeclaration)
-               && !((TypeDeclaration) declaration).isInterface();
-
-   }
-
-   @Override
-   public boolean isEnum()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return declaration instanceof EnumDeclaration;
-   }
-
-   @Override
-   public boolean isInterface()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return (declaration instanceof TypeDeclaration)
-               && ((TypeDeclaration) declaration).isInterface();
-   }
-
-   @Override
-   public boolean isAnnotation()
-   {
-      AbstractTypeDeclaration declaration = getBodyDeclaration();
-      return declaration instanceof AnnotationTypeDeclaration;
    }
 
    /*
@@ -878,7 +127,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       if (type instanceof AbstractJavaSource)
       {
-         List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+         List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
          BodyDeclaration nestedBody = ((AbstractJavaSource<?>) type).body;
          bodyDeclarations.add(ASTNode.copySubtree(unit.getAST(), nestedBody));
       }
@@ -895,7 +144,7 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       if (type instanceof AbstractJavaSource)
       {
          BodyDeclaration bodyDeclaration = ((AbstractJavaSource<?>) type).body;
-         List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+         List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
          bodyDeclarations.remove(bodyDeclaration);
       }
       return (O) this;
@@ -913,6 +162,107 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       JavaSource<?> nestedType = Roaster.parse(JavaSource.class, declaration);
       return (NESTED_TYPE) addNestedType(nestedType);
+   }
+
+   @Override
+   public boolean isStatic()
+   {
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+   }
+
+   @Override
+   public O setStatic(boolean _static)
+   {
+      if (_static)
+      {
+         modifiers.addModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+      }
+      else
+      {
+         modifiers.removeModifier(getDeclaration(), ModifierKeyword.STATIC_KEYWORD);
+      }
+      return (O) this;
+   }
+
+   private List<AbstractTypeDeclaration> getNestedDeclarations(BodyDeclaration body)
+   {
+      TypeDeclarationFinderVisitor typeDeclarationFinder = new TypeDeclarationFinderVisitor();
+      body.accept(typeDeclarationFinder);
+      List<AbstractTypeDeclaration> declarations = typeDeclarationFinder.getTypeDeclarations();
+
+      List<AbstractTypeDeclaration> result = new ArrayList<>(declarations);
+      if (!declarations.isEmpty())
+      {
+         // We don't want to return the current class' declaration.
+         result.remove(declarations.remove(0));
+         for (AbstractTypeDeclaration declaration : declarations)
+         {
+            result.removeAll(getNestedDeclarations(declaration));
+         }
+      }
+
+      return result;
+   }
+
+   @Override
+   protected AbstractTypeDeclaration getDeclaration()
+   {
+      if (body instanceof AbstractTypeDeclaration)
+         return (AbstractTypeDeclaration) body;
+      throw new ParserException("Source body was not of the expected type.");
+   }
+
+   @Override
+   public int hashCode()
+   {
+      return super.hashCode() + Objects.hash(body);
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
+      if (body == null)
+      {
+         if (other.body != null)
+            return false;
+      }
+      else if (!body.equals(other.body))
+         return false;
+      return super.equals(obj);
+   }
+
+   @SuppressWarnings("rawtypes")
+   @Override
+   public O setName(final String name)
+   {
+      AbstractTypeDeclaration typeDeclaration = getDeclaration();
+      TypeImpl<O> type = new TypeImpl(this, null, name);
+
+      typeDeclaration.setName(unit.getAST().newSimpleName(type.getName()));
+      if (typeDeclaration instanceof TypeDeclaration)
+      {
+         TypeDeclaration td = (TypeDeclaration) typeDeclaration;
+         for (Type<?> arg : type.getTypeArguments())
+         {
+            TypeParameter typeParameter = unit.getAST().newTypeParameter();
+            typeParameter.setName(unit.getAST().newSimpleName(arg.getName()));
+            td.typeParameters().add(typeParameter);
+         }
+      }
+      return updateTypeNames(name);
+   }
+
+   @Override
+   public String getName()
+   {
+      return getDeclaration().getName().getIdentifier();
    }
 
    @Override
@@ -939,67 +289,4 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    {
       return body.getJavadoc() != null;
    }
-
-   @Override
-   public boolean isStatic()
-   {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
-   }
-
-   @Override
-   public O setStatic(boolean _static)
-   {
-      if (_static)
-      {
-         modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
-      }
-      else
-      {
-         modifiers.removeModifier(getBodyDeclaration(), ModifierKeyword.STATIC_KEYWORD);
-      }
-      return (O) this;
-   }
-
-   private List<AbstractTypeDeclaration> getNestedDeclarations(BodyDeclaration body)
-   {
-      TypeDeclarationFinderVisitor typeDeclarationFinder = new TypeDeclarationFinderVisitor();
-      body.accept(typeDeclarationFinder);
-      List<AbstractTypeDeclaration> declarations = typeDeclarationFinder.getTypeDeclarations();
-
-      List<AbstractTypeDeclaration> result = new ArrayList<>(declarations);
-      if (!declarations.isEmpty())
-      {
-         // We don't want to return the current class' declaration.
-         result.remove(declarations.remove(0));
-         for (AbstractTypeDeclaration declaration : declarations)
-         {
-            result.removeAll(getNestedDeclarations(declaration));
-         }
-      }
-
-      return result;
-   }
-
-   @Override
-   public Import addImport(final Type<?> type)
-   {
-      Import imprt;
-      if (requiresImport(type.getQualifiedName()))
-      {
-         imprt = addImport(type.getQualifiedName());
-      }
-      else
-      {
-         imprt = getImport(type.getQualifiedName());
-      }
-      for (Type<?> arg : type.getTypeArguments())
-      {
-         if (!arg.isWildcard() && arg.isQualified())
-         {
-            addImport(arg);
-         }
-      }
-      return imprt;
-   }
-
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSourceMemberHolder.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSourceMemberHolder.java
@@ -68,7 +68,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public FieldSource<O> addField()
    {
-      FieldSource<O> field = new FieldImpl<O>((O) this);
+      FieldSource<O> field = new FieldImpl<>((O) this);
       addField(field);
       return field;
    }
@@ -84,7 +84,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
       for (FieldSource<JavaClassSource> stubField : fields)
       {
          Object variableDeclaration = stubField.getInternal();
-         FieldSource<O> field = new FieldImpl<O>((O) this, variableDeclaration, true);
+         FieldSource<O> field = new FieldImpl<>((O) this, variableDeclaration, true);
          addField(field);
          if (result == null)
          {
@@ -97,7 +97,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    private void addField(Field<O> field)
    {
-      List<Object> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+      List<Object> bodyDeclarations = getDeclaration().bodyDeclarations();
       int idx = 0;
       for (Object object : bodyDeclarations)
       {
@@ -113,7 +113,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @Override
    public List<MemberSource<O, ?>> getMembers()
    {
-      List<MemberSource<O, ?>> result = new ArrayList<MemberSource<O, ?>>();
+      List<MemberSource<O, ?>> result = new ArrayList<>();
 
       result.addAll(getFields());
       result.addAll(getMethods());
@@ -125,9 +125,9 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public List<FieldSource<O>> getFields()
    {
-      List<FieldSource<O>> result = new ArrayList<FieldSource<O>>();
+      List<FieldSource<O>> result = new ArrayList<>();
 
-      List<BodyDeclaration> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+      List<BodyDeclaration> bodyDeclarations = getDeclaration().bodyDeclarations();
       for (BodyDeclaration bodyDeclaration : bodyDeclarations)
       {
          if (bodyDeclaration instanceof FieldDeclaration)
@@ -136,7 +136,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
             List<VariableDeclarationFragment> fragments = fieldDeclaration.fragments();
             for (VariableDeclarationFragment fragment : fragments)
             {
-               result.add(new FieldImpl<O>((O) this, fragment));
+               result.add(new FieldImpl<>((O) this, fragment));
             }
          }
       }
@@ -181,7 +181,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    public O removeField(final Field<O> field)
    {
       VariableDeclarationFragment fragment = (VariableDeclarationFragment) field.getInternal();
-      Iterator<Object> declarationsIterator = getBodyDeclaration().bodyDeclarations().iterator();
+      Iterator<Object> declarationsIterator = getDeclaration().bodyDeclarations().iterator();
       while (declarationsIterator.hasNext())
       {
          Object next = declarationsIterator.next();
@@ -332,7 +332,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public O removeMethod(final Method<O, ?> method)
    {
-      getBodyDeclaration().bodyDeclarations().remove(method.getInternal());
+      getDeclaration().bodyDeclarations().remove(method.getInternal());
       return (O) this;
    }
 
@@ -340,8 +340,8 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public MethodSource<O> addMethod()
    {
-      MethodSource<O> m = new MethodImpl<O>((O) this);
-      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      MethodSource<O> m = new MethodImpl<>((O) this);
+      getDeclaration().bodyDeclarations().add(m.getInternal());
       return m;
    }
 
@@ -349,8 +349,8 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public MethodSource<O> addMethod(final String method)
    {
-      MethodSource<O> m = new MethodImpl<O>((O) this, method);
-      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      MethodSource<O> m = new MethodImpl<>((O) this, method);
+      getDeclaration().bodyDeclarations().add(m.getInternal());
       return m;
    }
 
@@ -358,8 +358,8 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public MethodSource<O> addMethod(java.lang.reflect.Method method)
    {
-      MethodSource<O> m = new MethodImpl<O>((O) this, method);
-      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      MethodSource<O> m = new MethodImpl<>((O) this, method);
+      getDeclaration().bodyDeclarations().add(m.getInternal());
       return m;
    }
 
@@ -367,8 +367,8 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public MethodSource<O> addMethod(Method<?, ?> method)
    {
-      MethodSource<O> m = new MethodImpl<O>((O) this, method.toString());
-      getBodyDeclaration().bodyDeclarations().add(m.getInternal());
+      MethodSource<O> m = new MethodImpl<>((O) this, method.toString());
+      getDeclaration().bodyDeclarations().add(m.getInternal());
       return m;
    }
 
@@ -376,7 +376,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @SuppressWarnings("unchecked")
    public List<MethodSource<O>> getMethods()
    {
-      List<MethodSource<O>> result = new ArrayList<MethodSource<O>>();
+      List<MethodSource<O>> result = new ArrayList<>();
 
       MethodFinderVisitor methodFinderVisitor = new MethodFinderVisitor();
       body.accept(methodFinderVisitor);
@@ -384,7 +384,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
       List<MethodDeclaration> methods = methodFinderVisitor.getMethods();
       for (MethodDeclaration methodDeclaration : methods)
       {
-         result.add(new MethodImpl<O>((O) this, methodDeclaration));
+         result.add(new MethodImpl<>((O) this, methodDeclaration));
       }
       return Collections.unmodifiableList(result);
    }
@@ -392,8 +392,8 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @Override
    public List<String> getInterfaces()
    {
-      List<String> result = new ArrayList<String>();
-      List<Type> superTypes = JDTHelper.getInterfaces(getBodyDeclaration());
+      List<String> result = new ArrayList<>();
+      List<Type> superTypes = JDTHelper.getInterfaces(getDeclaration());
       for (Type type : superTypes)
       {
          String name = JDTHelper.getTypeName(type);
@@ -431,13 +431,13 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
          Type interfaceType = JDTHelper.getInterfaces(
                   Roaster.parse(JavaInterfaceImpl.class,
                            "public interface Mock extends " + simpleName + " {}")
-                           .getBodyDeclaration())
+                           .getDeclaration())
                   .get(0);
 
          if (this.hasInterface(simpleName) || this.hasImport(simpleName))
          {
             interfaceType = JDTHelper.getInterfaces(Roaster.parse(JavaInterfaceImpl.class,
-                     "public interface Mock extends " + type + " {}").getBodyDeclaration()).get(0);
+                     "public interface Mock extends " + type + " {}").getDeclaration()).get(0);
          }
 
          if (!this.hasImport(simpleName))
@@ -446,7 +446,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
          }
 
          ASTNode node = ASTNode.copySubtree(unit.getAST(), interfaceType);
-         JDTHelper.getInterfaces(getBodyDeclaration()).add((Type) node);
+         JDTHelper.getInterfaces(getDeclaration()).add((Type) node);
       }
       return (O) this;
    }
@@ -475,7 +475,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
 
       if (type instanceof JavaInterfaceSource)
       {
-         Set<Import> usedImports = new HashSet<Import>();
+         Set<Import> usedImports = new HashSet<>();
 
          JavaInterfaceSource interfaceSource = (JavaInterfaceSource) type;
          for (MethodSource<JavaInterfaceSource> method : interfaceSource.getMethods())
@@ -548,7 +548,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @Override
    public O removeInterface(final String type)
    {
-      List<Type> interfaces = JDTHelper.getInterfaces(getBodyDeclaration());
+      List<Type> interfaces = JDTHelper.getInterfaces(getDeclaration());
       for (Type i : interfaces)
       {
          if (Types.areEquivalent(i.toString(), type))
@@ -601,7 +601,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
             origin.addImport(genericType);
          }
       }
-      final org.jboss.forge.roaster.model.Type<O> typeObject = new TypeImpl<O>(getOrigin(), null,
+      final org.jboss.forge.roaster.model.Type<O> typeObject = new TypeImpl<>(getOrigin(), null,
                Types.toSimpleName(type));
       final PropertySource<O> result = new PropertyImpl<O>(name, getOrigin())
       {
@@ -649,14 +649,14 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    public final PropertySource<O> getProperty(String name)
    {
       Assert.notNull(name, "name is null");
-      final PropertyImpl<O> result = new PropertyImpl<O>(name, getOrigin());
+      final PropertyImpl<O> result = new PropertyImpl<>(name, getOrigin());
       return result.isValid() ? result : null;
    }
 
    @Override
    public final List<PropertySource<O>> getProperties()
    {
-      final Set<String> propertyNames = new LinkedHashSet<String>();
+      final Set<String> propertyNames = new LinkedHashSet<>();
       for (MethodSource<O> method : getMethods())
       {
          if (isAccessor(method) || isMutator(method))
@@ -671,10 +671,10 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
             propertyNames.add(field.getName());
          }
       }
-      final List<PropertySource<O>> result = new ArrayList<PropertySource<O>>(propertyNames.size());
+      final List<PropertySource<O>> result = new ArrayList<>(propertyNames.size());
       for (String name : propertyNames)
       {
-         result.add(new PropertyImpl<O>(name, getOrigin()));
+         result.add(new PropertyImpl<>(name, getOrigin()));
       }
       return result;
    }
@@ -682,7 +682,7 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @Override
    public List<PropertySource<O>> getProperties(Class<?> type)
    {
-      final Set<String> propertyNames = new LinkedHashSet<String>();
+      final Set<String> propertyNames = new LinkedHashSet<>();
       for (MethodSource<O> method : getMethods())
       {
          if ((isAccessor(method) || isMutator(method))
@@ -698,10 +698,10 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
             propertyNames.add(field.getName());
          }
       }
-      final List<PropertySource<O>> result = new ArrayList<PropertySource<O>>(propertyNames.size());
+      final List<PropertySource<O>> result = new ArrayList<>(propertyNames.size());
       for (String name : propertyNames)
       {
-         result.add(new PropertyImpl<O>(name, getOrigin()));
+         result.add(new PropertyImpl<>(name, getOrigin()));
       }
       return result;
    }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaAnnotationImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaAnnotationImpl.java
@@ -55,7 +55,7 @@ public class JavaAnnotationImpl extends AbstractJavaSource<JavaAnnotationSource>
    private AnnotationElementSource add(AnnotationElementSource annotationElement)
    {
       @SuppressWarnings("unchecked")
-      final ListIterator<BodyDeclaration> members = getBodyDeclaration().bodyDeclarations().listIterator();
+      final ListIterator<BodyDeclaration> members = getDeclaration().bodyDeclarations().listIterator();
 
       // skip any members before annotation elements, i.e. nested types
       while (members.hasNext())
@@ -115,9 +115,9 @@ public class JavaAnnotationImpl extends AbstractJavaSource<JavaAnnotationSource>
    @Override
    public List<AnnotationElementSource> getAnnotationElements()
    {
-      List<AnnotationElementSource> result = new ArrayList<AnnotationElementSource>();
+      List<AnnotationElementSource> result = new ArrayList<>();
       @SuppressWarnings("unchecked")
-      List<BodyDeclaration> bodyDeclarations = getBodyDeclaration().bodyDeclarations();
+      List<BodyDeclaration> bodyDeclarations = getDeclaration().bodyDeclarations();
       for (BodyDeclaration bodyDeclaration : bodyDeclarations)
       {
          if (bodyDeclaration instanceof AnnotationTypeMemberDeclaration)
@@ -132,7 +132,7 @@ public class JavaAnnotationImpl extends AbstractJavaSource<JavaAnnotationSource>
    @Override
    public JavaAnnotationSource removeAnnotationElement(AnnotationElement<?> annotationElement)
    {
-      getBodyDeclaration().bodyDeclarations().remove(annotationElement.getInternal());
+      getDeclaration().bodyDeclarations().remove(annotationElement.getInternal());
       return this;
    }
 

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaClassImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaClassImpl.java
@@ -59,7 +59,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
    @Override
    public boolean isAbstract()
    {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.ABSTRACT_KEYWORD);
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.ABSTRACT_KEYWORD);
    }
 
    @Override
@@ -67,11 +67,11 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
    {
       if (abstrct)
       {
-         modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.ABSTRACT_KEYWORD);
+         modifiers.addModifier(getDeclaration(), ModifierKeyword.ABSTRACT_KEYWORD);
       }
       else
       {
-         modifiers.removeModifier(getBodyDeclaration(), ModifierKeyword.ABSTRACT_KEYWORD);
+         modifiers.removeModifier(getDeclaration(), ModifierKeyword.ABSTRACT_KEYWORD);
       }
       return this;
    }
@@ -79,23 +79,23 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
    @Override
    public boolean isFinal()
    {
-      return modifiers.hasModifier(getBodyDeclaration(), ModifierKeyword.FINAL_KEYWORD);
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.FINAL_KEYWORD);
    }
 
    @Override
    public JavaClassSource setFinal(boolean finl)
    {
       if (finl)
-         modifiers.addModifier(getBodyDeclaration(), ModifierKeyword.FINAL_KEYWORD);
+         modifiers.addModifier(getDeclaration(), ModifierKeyword.FINAL_KEYWORD);
       else
-         modifiers.removeModifier(getBodyDeclaration(), ModifierKeyword.FINAL_KEYWORD);
+         modifiers.removeModifier(getDeclaration(), ModifierKeyword.FINAL_KEYWORD);
       return this;
    }
 
    @Override
    public boolean isLocalClass()
    {
-      return JDTHelper.isLocalClass(getBodyDeclaration());
+      return JDTHelper.isLocalClass(getDeclaration());
    }
 
    @Override
@@ -117,7 +117,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
    @Override
    public String getSuperType()
    {
-      Object superType = getBodyDeclaration().getStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY);
+      Object superType = getDeclaration().getStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY);
       if (superType == null)
          superType = Object.class.getName();
       return resolveType(superType.toString()) + Types.getGenerics(superType.toString());
@@ -193,7 +193,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
             pt.typeArguments().add(t);
          }
 
-         getBodyDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, pt);
+         getDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, pt);
       }
       else
       {
@@ -213,7 +213,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
             superType = body.getAST().newSimpleType(simpleName);
          }
 
-         getBodyDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, superType);
+         getDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, superType);
       }
 
       return this;
@@ -232,7 +232,7 @@ public class JavaClassImpl extends AbstractGenericCapableJavaSource<JavaClassSou
    {
       if (type == null)
       {
-         getBodyDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, null);
+         getDeclaration().setStructuralProperty(TypeDeclaration.SUPERCLASS_TYPE_PROPERTY, null);
          return true;
       }
       return false;

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaEnumImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaEnumImpl.java
@@ -35,9 +35,9 @@ public class JavaEnumImpl extends AbstractJavaSourceMemberHolder<JavaEnumSource>
    @Override
    public List<EnumConstantSource> getEnumConstants()
    {
-      List<EnumConstantSource> result = new ArrayList<EnumConstantSource>();
+      List<EnumConstantSource> result = new ArrayList<>();
 
-      for (Object o : ((EnumDeclaration) getBodyDeclaration()).enumConstants())
+      for (Object o : ((EnumDeclaration) getDeclaration()).enumConstants())
       {
          EnumConstantDeclaration constant = (EnumConstantDeclaration) o;
          result.add(new EnumConstantImpl(this, constant));
@@ -51,7 +51,7 @@ public class JavaEnumImpl extends AbstractJavaSourceMemberHolder<JavaEnumSource>
    public EnumConstantSource addEnumConstant()
    {
       EnumConstantImpl enumConst = new EnumConstantImpl(this);
-      EnumDeclaration enumDeclaration = (EnumDeclaration) getBodyDeclaration();
+      EnumDeclaration enumDeclaration = (EnumDeclaration) getDeclaration();
       List<EnumConstantDeclaration> constants = enumDeclaration.enumConstants();
       constants.add((EnumConstantDeclaration) enumConst.getInternal());
 
@@ -64,7 +64,7 @@ public class JavaEnumImpl extends AbstractJavaSourceMemberHolder<JavaEnumSource>
    {
       EnumConstantImpl enumConst = new EnumConstantImpl(this, declaration);
 
-      EnumDeclaration enumDeclaration = (EnumDeclaration) getBodyDeclaration();
+      EnumDeclaration enumDeclaration = (EnumDeclaration) getDeclaration();
       List<EnumConstantDeclaration> constants = enumDeclaration.enumConstants();
       constants.add((EnumConstantDeclaration) enumConst.getInternal());
 

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -6,55 +6,30 @@
  */
 package org.jboss.forge.roaster.model.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.ServiceLoader;
+import java.util.Objects;
 
-import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
-import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jface.text.Document;
 import org.eclipse.text.edits.TextEdit;
 import org.jboss.forge.roaster.ParserException;
-import org.jboss.forge.roaster.model.Annotation;
 import org.jboss.forge.roaster.model.JavaType;
-import org.jboss.forge.roaster.model.SyntaxError;
-import org.jboss.forge.roaster.model.Type;
-import org.jboss.forge.roaster.model.Visibility;
-import org.jboss.forge.roaster.model.ast.AnnotationAccessor;
-import org.jboss.forge.roaster.model.ast.ModifierAccessor;
-import org.jboss.forge.roaster.model.source.AnnotationSource;
-import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaDocSource;
 import org.jboss.forge.roaster.model.source.JavaPackageInfoSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.util.Formatter;
-import org.jboss.forge.roaster.model.util.Strings;
-import org.jboss.forge.roaster.model.util.Types;
-import org.jboss.forge.roaster.spi.WildcardImportResolver;
 
-public class JavaPackageInfoImpl implements JavaPackageInfoSource
+public class JavaPackageInfoImpl<O extends JavaPackageInfoSource> extends JavaSourceImpl<JavaPackageInfoSource>
+         implements JavaPackageInfoSource
 {
-   protected final Document document;
-   protected final CompilationUnit unit;
-   protected final PackageDeclaration pkg;
-   protected final JavaSource<?> enclosingType;
 
-   private final AnnotationAccessor<JavaPackageInfoSource, JavaPackageInfoSource> annotations = new AnnotationAccessor<JavaPackageInfoSource, JavaPackageInfoSource>();
-   private final ModifierAccessor modifiers = new ModifierAccessor();
-
-   private static List<WildcardImportResolver> resolvers;
-
+   private PackageDeclaration pkg;
    public JavaPackageInfoImpl(JavaSource<?> enclosingType, Document document,
             CompilationUnit unit, PackageDeclaration pkg)
    {
-      this.enclosingType = enclosingType == null ? this : enclosingType;
-      this.document = document;
-      this.unit = unit;
+      super(enclosingType, document, unit);
       this.pkg = pkg;
    }
 
@@ -65,522 +40,19 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    }
 
    @Override
-   public JavaSource<?> getEnclosingType()
+   protected ASTNode getDeclaration()
    {
-      return enclosingType;
-   }
-
-   /*
-    * Annotation modifiers
-    */
-   @Override
-   public AnnotationSource<JavaPackageInfoSource> addAnnotation()
-   {
-      return annotations.addAnnotation(this, getPackageDeclaration());
-   }
-
-   @Override
-   public AnnotationSource<JavaPackageInfoSource> addAnnotation(
-            final Class<? extends java.lang.annotation.Annotation> clazz)
-   {
-      return annotations.addAnnotation(this, getPackageDeclaration(), clazz.getName());
-   }
-
-   @Override
-   public AnnotationSource<JavaPackageInfoSource> addAnnotation(final String className)
-   {
-      return annotations.addAnnotation(this, getPackageDeclaration(), className);
-   }
-
-   @Override
-   public List<AnnotationSource<JavaPackageInfoSource>> getAnnotations()
-   {
-      return annotations.getAnnotations(this, getPackageDeclaration());
-   }
-
-   @Override
-   public boolean hasAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
-   {
-      return annotations.hasAnnotation(this, getPackageDeclaration(), type.getName());
-   }
-
-   @Override
-   public boolean hasAnnotation(final String type)
-   {
-      return annotations.hasAnnotation(this, getPackageDeclaration(), type);
-   }
-
-   @Override
-   public JavaPackageInfoSource removeAnnotation(final Annotation<JavaPackageInfoSource> annotation)
-   {
-      return annotations.removeAnnotation(this, getPackageDeclaration(), annotation);
-   }
-
-   @Override
-   public void removeAllAnnotations()
-   {
-      annotations.removeAllAnnotations(getPackageDeclaration());
-   }
-
-   @Override
-   public AnnotationSource<JavaPackageInfoSource> getAnnotation(
-            final Class<? extends java.lang.annotation.Annotation> type)
-   {
-      return annotations.getAnnotation(this, getPackageDeclaration(), type);
-   }
-
-   @Override
-   public AnnotationSource<JavaPackageInfoSource> getAnnotation(final String type)
-   {
-      return annotations.getAnnotation(this, getPackageDeclaration(), type);
-   }
-
-   /*
-    * Import modifiers
-    */
-
-   @Override
-   public Import addImport(final Class<?> type)
-   {
-      return addImport(type.getCanonicalName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> Import addImport(final T type)
-   {
-      String qualifiedName = type.getQualifiedName();
-      return this.addImport(qualifiedName);
-   }
-
-   @Override
-   public Import addImport(final Import imprt)
-   {
-      return addImport(imprt.getQualifiedName()).setStatic(imprt.isStatic());
-   }
-
-   @Override
-   @SuppressWarnings("unchecked")
-   public Import addImport(final String className)
-   {
-      String strippedClassName = Types.stripGenerics(Types.stripArray(className));
-      Import imprt;
-      if (Types.isSimpleName(strippedClassName) && !hasImport(strippedClassName))
+      if (pkg != null)
       {
-         throw new IllegalArgumentException("Cannot import class without a package [" + strippedClassName + "]");
-      }
-
-      if (!hasImport(strippedClassName) && validImport(strippedClassName))
-      {
-         imprt = new ImportImpl(this).setName(strippedClassName);
-         unit.imports().add(imprt.getInternal());
-      }
-      else if (hasImport(strippedClassName))
-      {
-         imprt = getImport(strippedClassName);
-      }
-      else
-      {
-         throw new IllegalArgumentException("Attempted to import the illegal type [" + strippedClassName + "]");
-      }
-      return imprt;
-   }
-
-   @Override
-   public Import getImport(final String className)
-   {
-      List<Import> imports = getImports();
-      for (Import imprt : imports)
-      {
-         if (imprt.getQualifiedName().equals(className) || imprt.getSimpleName().equals(className))
-         {
-            return imprt;
-         }
-      }
-      return null;
-   }
-
-   @Override
-   public Import getImport(final Class<?> type)
-   {
-      return getImport(type.getName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> Import getImport(final T type)
-   {
-      return getImport(type.getQualifiedName());
-   }
-
-   @Override
-   public Import getImport(final Import imprt)
-   {
-      return getImport(imprt.getQualifiedName());
-   }
-
-   @Override
-   @SuppressWarnings("unchecked")
-   public List<Import> getImports()
-   {
-      List<Import> results = new ArrayList<Import>();
-
-      for (ImportDeclaration i : (List<ImportDeclaration>) unit.imports())
-      {
-         results.add(new ImportImpl(this, i));
-      }
-
-      return Collections.unmodifiableList(results);
-   }
-
-   @Override
-   public boolean hasImport(final Class<?> type)
-   {
-      return hasImport(type.getName());
-   }
-
-   @Override
-   public <T extends JavaType<T>> boolean hasImport(final T type)
-   {
-      return hasImport(type.getQualifiedName());
-   }
-
-   @Override
-   public boolean hasImport(final Import imprt)
-   {
-      return hasImport(imprt.getQualifiedName());
-   }
-
-   @Override
-   public boolean hasImport(final String type)
-   {
-      String resultType = type;
-      if (Types.isArray(type))
-      {
-         resultType = Types.stripArray(type);
-      }
-      if (Types.isGeneric(type))
-      {
-         resultType = Types.stripGenerics(type);
-      }
-      return getImport(resultType) != null;
-   }
-
-   @Override
-   public boolean requiresImport(final Class<?> type)
-   {
-      return requiresImport(type.getName());
-   }
-
-   @Override
-   public boolean requiresImport(final String type)
-   {
-      String resultType = type;
-      if (Types.isArray(resultType))
-      {
-         resultType = Types.stripArray(type);
-      }
-      if (Types.isGeneric(resultType))
-      {
-         resultType = Types.stripGenerics(resultType);
-      }
-      return !(!validImport(resultType)
-               || hasImport(resultType)
-               || Types.isJavaLang(resultType));
-   }
-
-   @Override
-   public String resolveType(final String type)
-   {
-      String original = type;
-      String result = type;
-
-      // Strip away any characters that might hinder the type matching process
-      if (Types.isArray(result))
-      {
-         original = Types.stripArray(result);
-         result = Types.stripArray(result);
-      }
-
-      if (Types.isGeneric(result))
-      {
-         original = Types.stripGenerics(result);
-         result = Types.stripGenerics(result);
-      }
-
-      if (Types.isPrimitive(result))
-      {
-         return result;
-      }
-
-      // Check for direct import matches first since they are the fastest and least work-intensive
-      if (Types.isSimpleName(result))
-      {
-         if (!hasImport(type) && Types.isJavaLang(type))
-         {
-            result = "java.lang." + result;
-         }
-
-         if (result.equals(original))
-         {
-            for (Import imprt : getImports())
-            {
-               if (Types.areEquivalent(result, imprt.getQualifiedName()))
-               {
-                  result = imprt.getQualifiedName();
-                  break;
-               }
-            }
-         }
-      }
-
-      // If we didn't match any imports directly, we might have a wild-card/on-demand import.
-      if (Types.isSimpleName(result))
-      {
-         for (Import imprt : getImports())
-         {
-            if (imprt.isWildcard())
-            {
-               // TODO warn if no wild-card resolvers are configured
-               // TODO Test wild-card/on-demand import resolving
-               for (WildcardImportResolver r : getImportResolvers())
-               {
-                  result = r.resolve(this, result);
-                  if (Types.isQualified(result))
-                     break;
-               }
-            }
-         }
-      }
-
-      // No import matches and no wild-card/on-demand import matches means this class is in the same package.
-      if (Types.isSimpleName(result))
-      {
-         if (getPackage() != null)
-            result = getPackage() + "." + result;
-      }
-
-      return result;
-   }
-
-   private List<WildcardImportResolver> getImportResolvers()
-   {
-      if (resolvers == null)
-      {
-         resolvers = new ArrayList<WildcardImportResolver>();
-         for (WildcardImportResolver r : ServiceLoader.load(WildcardImportResolver.class, getClass().getClassLoader()))
-         {
-            resolvers.add(r);
-         }
-      }
-      if (resolvers.size() == 0)
-      {
-         throw new IllegalStateException("No instances of [" + WildcardImportResolver.class.getName()
-                  + "] were found on the classpath.");
-      }
-      return resolvers;
-   }
-
-   private boolean validImport(final String type)
-   {
-      return !Strings.isNullOrEmpty(type) && !Types.isPrimitive(type);
-   }
-
-   @Override
-   public JavaPackageInfoSource removeImport(final String name)
-   {
-      for (Import i : getImports())
-      {
-         if (i.getQualifiedName().equals(name))
-         {
-            removeImport(i);
-            break;
-         }
-      }
-      return this;
-   }
-
-   @Override
-   public JavaPackageInfoSource removeImport(final Class<?> clazz)
-   {
-      return removeImport(clazz.getName());
-   }
-
-   @Override
-   public <T extends JavaType<?>> JavaPackageInfoSource removeImport(final T type)
-   {
-      return removeImport(type.getQualifiedName());
-   }
-
-   @Override
-   public JavaPackageInfoSource removeImport(final Import imprt)
-   {
-      Object internal = imprt.getInternal();
-      if (unit.imports().contains(internal))
-      {
-         unit.imports().remove(internal);
-      }
-      return this;
-   }
-
-   protected PackageDeclaration getPackageDeclaration()
-   {
-      if (pkg instanceof PackageDeclaration)
          return pkg;
+      }
       throw new ParserException("Source body was not of the expected type (PackageDeclaration).");
    }
 
    @Override
-   public JavaPackageInfoSource setName(final String name)
+   public O setName(final String name)
    {
       throw new UnsupportedOperationException("Changing name of [" + getQualifiedName() + "] not supported.");
-   }
-
-   @Override
-   public String getCanonicalName()
-   {
-      String result = getName();
-
-      JavaType<?> enclosingTypeLocal = this;
-      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
-      {
-         enclosingTypeLocal = getEnclosingType();
-         result = enclosingTypeLocal.getEnclosingType().getName() + "." + result;
-         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
-      }
-
-      if (!Strings.isNullOrEmpty(getPackage()))
-         result = getPackage() + "." + result;
-
-      return result;
-   }
-
-   @Override
-   public String getQualifiedName()
-   {
-      String result = getName();
-
-      JavaType<?> enclosingTypeLocal = this;
-      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
-      {
-         enclosingTypeLocal = getEnclosingType();
-         result = enclosingTypeLocal.getEnclosingType().getName() + "$" + result;
-         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
-      }
-
-      if (!Strings.isNullOrEmpty(getPackage()))
-         result = getPackage() + "." + result;
-
-      return result;
-   }
-
-   /*
-    * Package modifiers
-    */
-   @Override
-   public String getPackage()
-   {
-      PackageDeclaration pkgLocal = unit.getPackage();
-      if (pkgLocal != null)
-      {
-         return pkgLocal.getName().getFullyQualifiedName();
-      }
-      else
-      {
-         return null;
-      }
-   }
-
-   @Override
-   public JavaPackageInfoSource setPackage(final String name)
-   {
-      if (unit.getPackage() == null)
-      {
-         unit.setPackage(unit.getAST().newPackageDeclaration());
-      }
-      unit.getPackage().setName(unit.getAST().newName(name));
-      return this;
-   }
-
-   @Override
-   public JavaPackageInfoSource setDefaultPackage()
-   {
-      unit.setPackage(null);
-      return this;
-   }
-
-   @Override
-   public boolean isDefaultPackage()
-   {
-      return unit.getPackage() == null;
-   }
-
-   /*
-    * Visibility modifiers
-    */
-   @Override
-   public boolean isPackagePrivate()
-   {
-      return !isPublic() && !isPrivate() && !isProtected();
-   }
-
-   @Override
-   public JavaPackageInfoSource setPackagePrivate()
-   {
-      modifiers.clearVisibility(getPackageDeclaration());
-      return this;
-   }
-
-   @Override
-   public boolean isPublic()
-   {
-      return modifiers.hasModifier(getPackageDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
-   }
-
-   @Override
-   public JavaPackageInfoSource setPublic()
-   {
-      modifiers.clearVisibility(getPackageDeclaration());
-      modifiers.addModifier(getPackageDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
-      return this;
-   }
-
-   @Override
-   public boolean isPrivate()
-   {
-      return modifiers.hasModifier(getPackageDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
-   }
-
-   @Override
-   public JavaPackageInfoSource setPrivate()
-   {
-      modifiers.clearVisibility(getPackageDeclaration());
-      modifiers.addModifier(getPackageDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
-      return this;
-   }
-
-   @Override
-   public boolean isProtected()
-   {
-      return modifiers.hasModifier(getPackageDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
-   }
-
-   @Override
-   public JavaPackageInfoSource setProtected()
-   {
-      modifiers.clearVisibility(getPackageDeclaration());
-      modifiers.addModifier(getPackageDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
-      return this;
-   }
-
-   @Override
-   public Visibility getVisibility()
-   {
-      return Visibility.getFrom(this);
-   }
-
-   @Override
-   public JavaPackageInfoSource setVisibility(final Visibility scope)
-   {
-      return Visibility.set(this, scope);
    }
 
    /*
@@ -614,27 +86,9 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
    }
 
    @Override
-   public Object getInternal()
-   {
-      return unit;
-   }
-
-   @Override
-   public JavaPackageInfoSource getOrigin()
-   {
-      return this;
-   }
-
-   @Override
    public int hashCode()
    {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((pkg == null) ? 0 : pkg.hashCode());
-      result = prime * result + ((document == null) ? 0 : document.hashCode());
-      result = prime * result + ((enclosingType == null) ? 0 : enclosingType.hashCode());
-      result = prime * result + ((unit == null) ? 0 : unit.hashCode());
-      return result;
+      return super.hashCode() + Objects.hashCode(pkg);
    }
 
    @Override
@@ -646,7 +100,7 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
          return false;
       if (getClass() != obj.getClass())
          return false;
-      JavaPackageInfoImpl other = (JavaPackageInfoImpl) obj;
+      JavaPackageInfoImpl<?> other = (JavaPackageInfoImpl<?>) obj;
       if (pkg == null)
       {
          if (other.pkg != null)
@@ -654,80 +108,12 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
       }
       else if (!pkg.equals(other.pkg))
          return false;
-      if (document == null)
-      {
-         if (other.document != null)
-            return false;
-      }
-      else if (!document.equals(other.document))
-         return false;
-      if (enclosingType == null)
-      {
-         if (other.enclosingType != null)
-            return false;
-      }
-      else if (!enclosingType.equals(other.enclosingType))
-         return false;
-      if (unit == null)
-      {
-         if (other.unit != null)
-            return false;
-      }
-      else if (!unit.equals(other.unit))
-         return false;
-      return true;
+      return super.equals(obj);
    }
 
-   @Override
-   public List<SyntaxError> getSyntaxErrors()
+   public PackageDeclaration getPkg()
    {
-      List<SyntaxError> result = new ArrayList<SyntaxError>();
-
-      IProblem[] problems = unit.getProblems();
-      if (problems != null)
-      {
-         for (IProblem problem : problems)
-         {
-            result.add(new SyntaxErrorImpl(this, problem));
-         }
-      }
-      return result;
-   }
-
-   @Override
-   public boolean hasSyntaxErrors()
-   {
-      return !getSyntaxErrors().isEmpty();
-   }
-
-   @Override
-   public boolean isClass()
-   {
-      return false;
-   }
-
-   @Override
-   public boolean isEnum()
-   {
-      return false;
-   }
-
-   @Override
-   public boolean isInterface()
-   {
-      return false;
-   }
-
-   @Override
-   public boolean isAnnotation()
-   {
-      return false;
-   }
-
-   @Override
-   public Import addImport(Type<?> type)
-   {
-      return addImport(type.getQualifiedName());
+      return pkg;
    }
 
    @Override
@@ -739,7 +125,7 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
          javadoc = pkg.getAST().newJavadoc();
          pkg.setJavadoc(javadoc);
       }
-      return new JavaDocImpl<JavaPackageInfoSource>(this, javadoc);
+      return new JavaDocImpl<>(this, javadoc);
    }
 
    @Override
@@ -755,13 +141,9 @@ public class JavaPackageInfoImpl implements JavaPackageInfoSource
       return pkg.getJavadoc() != null;
    }
 
-   public CompilationUnit getUnit()
+   @Override
+   protected JavaPackageInfoSource updateTypeNames(String name)
    {
-      return unit;
-   }
-
-   public PackageDeclaration getPkg()
-   {
-      return pkg;
+     throw new ParserException();
    }
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -21,7 +21,7 @@ import org.jboss.forge.roaster.model.source.JavaPackageInfoSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.util.Formatter;
 
-public class JavaPackageInfoImpl<O extends JavaPackageInfoSource> extends JavaSourceImpl<JavaPackageInfoSource>
+public class JavaPackageInfoImpl extends JavaSourceImpl<JavaPackageInfoSource>
          implements JavaPackageInfoSource
 {
 
@@ -50,7 +50,7 @@ public class JavaPackageInfoImpl<O extends JavaPackageInfoSource> extends JavaSo
    }
 
    @Override
-   public O setName(final String name)
+   public JavaPackageInfoImpl setName(final String name)
    {
       throw new UnsupportedOperationException("Changing name of [" + getQualifiedName() + "] not supported.");
    }
@@ -100,7 +100,7 @@ public class JavaPackageInfoImpl<O extends JavaPackageInfoSource> extends JavaSo
          return false;
       if (getClass() != obj.getClass())
          return false;
-      JavaPackageInfoImpl<?> other = (JavaPackageInfoImpl<?>) obj;
+      JavaPackageInfoImpl other = (JavaPackageInfoImpl) obj;
       if (pkg == null)
       {
          if (other.pkg != null)

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+*/
 package org.jboss.forge.roaster.model.impl;
 
 import java.util.ArrayList;

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
@@ -1,0 +1,781 @@
+package org.jboss.forge.roaster.model.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.TextEdit;
+import org.jboss.forge.roaster.ParserException;
+import org.jboss.forge.roaster.model.Annotation;
+import org.jboss.forge.roaster.model.JavaType;
+import org.jboss.forge.roaster.model.SyntaxError;
+import org.jboss.forge.roaster.model.Type;
+import org.jboss.forge.roaster.model.Visibility;
+import org.jboss.forge.roaster.model.ast.AnnotationAccessor;
+import org.jboss.forge.roaster.model.ast.ModifierAccessor;
+import org.jboss.forge.roaster.model.source.AnnotationSource;
+import org.jboss.forge.roaster.model.source.Import;
+import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.util.Formatter;
+import org.jboss.forge.roaster.model.util.Strings;
+import org.jboss.forge.roaster.model.util.Types;
+import org.jboss.forge.roaster.spi.WildcardImportResolver;
+
+/**
+ * Represents a Java Source File
+ *
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSource<O>
+{
+   private static List<WildcardImportResolver> resolvers;
+   private final ModifierAccessor modifiers = new ModifierAccessor();
+   private final AnnotationAccessor<O, O> annotations = new AnnotationAccessor<>();
+
+   protected final Document document;
+   protected final CompilationUnit unit;
+   protected final JavaSource<?> enclosingType;
+
+   protected JavaSourceImpl(JavaSource<?> enclosingType, final Document document, final CompilationUnit unit)
+   {
+      this.enclosingType = enclosingType == null ? this : enclosingType;
+      this.document = document;
+      this.unit = unit;
+   }
+
+   // ================================================================================
+   // Annotation
+   // ================================================================================
+
+   @Override
+   public AnnotationSource<O> addAnnotation()
+   {
+      return annotations.addAnnotation(this, getDeclaration());
+   }
+
+   @Override
+   public List<AnnotationSource<O>> getAnnotations()
+   {
+      return annotations.getAnnotations(this, getDeclaration());
+   }
+
+   @Override
+   public AnnotationSource<O> addAnnotation(final Class<? extends java.lang.annotation.Annotation> clazz)
+   {
+      return annotations.addAnnotation(this, getDeclaration(), clazz.getName());
+   }
+
+   @Override
+   public AnnotationSource<O> addAnnotation(final String className)
+   {
+      return annotations.addAnnotation(this, getDeclaration(), className);
+   }
+
+   @Override
+   public boolean hasAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
+   {
+      return annotations.hasAnnotation(this, getDeclaration(), type.getName());
+   }
+
+   @Override
+   public boolean hasAnnotation(final String type)
+   {
+      return annotations.hasAnnotation(this, getDeclaration(), type);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O removeAnnotation(final Annotation<O> annotation)
+   {
+      return (O) annotations.removeAnnotation(this, getDeclaration(), annotation);
+   }
+
+   @Override
+   public void removeAllAnnotations()
+   {
+      annotations.removeAllAnnotations(getDeclaration());
+   }
+
+   @Override
+   public AnnotationSource<O> getAnnotation(final Class<? extends java.lang.annotation.Annotation> type)
+   {
+      return annotations.getAnnotation(this, getDeclaration(), type);
+   }
+
+   @Override
+   public AnnotationSource<O> getAnnotation(final String type)
+   {
+      return annotations.getAnnotation(this, getDeclaration(), type);
+   }
+
+   // ================================================================================
+   // Import
+   // ================================================================================
+
+   @Override
+   public Import addImport(final Class<?> type)
+   {
+      return addImport(type.getCanonicalName());
+   }
+
+   @Override
+   public <T extends JavaType<?>> Import addImport(final T type)
+   {
+      String qualifiedName = type.getQualifiedName();
+      return this.addImport(qualifiedName);
+   }
+
+   @Override
+   public Import addImport(final Import imprt)
+   {
+      return addImport(imprt.getQualifiedName()).setStatic(imprt.isStatic());
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public Import addImport(final String className)
+   {
+      String strippedClassName = Types.stripGenerics(Types.stripArray(className));
+
+      if (Types.isGeneric(className))
+      {
+         for (String genericPart : Types.splitGenerics(className))
+         {
+            if (Types.isQualified(genericPart))
+               addImport(genericPart);
+         }
+      }
+
+      Import imprt;
+      if (!hasImport(strippedClassName) && validImport(strippedClassName))
+      {
+         imprt = new ImportImpl(this).setName(strippedClassName);
+         unit.imports().add(imprt.getInternal());
+      }
+      else if (hasImport(strippedClassName))
+      {
+         imprt = getImport(strippedClassName);
+      }
+      else
+      {
+         imprt = null;
+      }
+      return imprt;
+   }
+
+   @Override
+   public Import getImport(final String className)
+   {
+      List<Import> imports = getImports();
+      for (Import imprt : imports)
+      {
+         if (imprt.getQualifiedName().equals(className) || imprt.getSimpleName().equals(className))
+         {
+            return imprt;
+         }
+      }
+      return null;
+   }
+
+   @Override
+   public Import addImport(final Type<?> type)
+   {
+      Import imprt;
+      if (requiresImport(type.getQualifiedName()))
+      {
+         imprt = addImport(type.getQualifiedName());
+      }
+      else
+      {
+         imprt = getImport(type.getQualifiedName());
+      }
+      for (Type<?> arg : type.getTypeArguments())
+      {
+         if (!arg.isWildcard() && arg.isQualified())
+         {
+            addImport(arg);
+         }
+      }
+      return imprt;
+   }
+
+   @Override
+   public Import getImport(final Class<?> type)
+   {
+      return getImport(type.getName());
+   }
+
+   @Override
+   public <T extends JavaType<?>> Import getImport(final T type)
+   {
+      return getImport(type.getQualifiedName());
+   }
+
+   @Override
+   public Import getImport(final Import imprt)
+   {
+      return getImport(imprt.getQualifiedName());
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public List<Import> getImports()
+   {
+      List<Import> results = new ArrayList<>();
+
+      for (ImportDeclaration i : (List<ImportDeclaration>) unit.imports())
+      {
+         results.add(new ImportImpl(this, i));
+      }
+
+      return Collections.unmodifiableList(results);
+   }
+
+   @Override
+   public boolean hasImport(final Class<?> type)
+   {
+      return hasImport(type.getName());
+   }
+
+   @Override
+   public <T extends JavaType<T>> boolean hasImport(final T type)
+   {
+      return hasImport(type.getQualifiedName());
+   }
+
+   @Override
+   public boolean hasImport(final Import imprt)
+   {
+      return hasImport(imprt.getQualifiedName());
+   }
+
+   @Override
+   public boolean hasImport(final String type)
+   {
+      String resultType = type;
+      if (Types.isArray(type))
+      {
+         resultType = Types.stripArray(type);
+      }
+      if (Types.isGeneric(type))
+      {
+         resultType = Types.stripGenerics(type);
+      }
+      return getImport(resultType) != null;
+   }
+
+   @Override
+   public boolean requiresImport(final Class<?> type)
+   {
+      return requiresImport(type.getName());
+   }
+
+   @Override
+   public boolean requiresImport(final String type)
+   {
+      boolean requiresImport = false;
+      String resultType = type;
+      if (Types.isArray(resultType))
+      {
+         resultType = Types.stripArray(resultType);
+      }
+      if (Types.isGeneric(resultType))
+      {
+         for (String genericPart : Types.splitGenerics(resultType))
+         {
+            requiresImport |= requiresImport(genericPart);
+         }
+         resultType = Types.stripGenerics(resultType);
+      }
+      requiresImport |= !(!validImport(resultType)
+               || hasImport(resultType)
+               || Types.isJavaLang(resultType)
+               || Strings.areEqual(getPackage(), Types.getPackage(resultType)));
+      return requiresImport;
+   }
+
+   @Override
+   public String resolveType(final String type)
+   {
+      String original = type;
+      String result = type;
+
+      // Strip away any characters that might hinder the type matching process
+      if (Types.isArray(result))
+      {
+         original = Types.stripArray(result);
+         result = Types.stripArray(result);
+      }
+
+      if (Types.isGeneric(result))
+      {
+         original = Types.stripGenerics(result);
+         result = Types.stripGenerics(result);
+      }
+
+      if (Types.isPrimitive(result))
+      {
+         return result;
+      }
+
+      // Check for direct import matches first since they are the fastest and least work-intensive
+      if (Types.isSimpleName(result))
+      {
+         if (!hasImport(result) && Types.isJavaLang(result))
+         {
+            result = "java.lang." + result;
+         }
+
+         if (result.equals(original))
+         {
+            for (Import imprt : getImports())
+            {
+               if (Types.areEquivalent(result, imprt.getQualifiedName()))
+               {
+                  result = imprt.getQualifiedName();
+                  break;
+               }
+            }
+         }
+      }
+
+      // If we didn't match any imports directly, we might have a wild-card/on-demand import.
+      if (Types.isSimpleName(result))
+      {
+         for (Import imprt : getImports())
+         {
+            if (imprt.isWildcard())
+            {
+               // TODO warn if no wild-card resolvers are configured
+               // TODO Test wild-card/on-demand import resolving
+               for (WildcardImportResolver r : getImportResolvers())
+               {
+                  result = r.resolve(this, result);
+                  if (Types.isQualified(result))
+                     break;
+               }
+            }
+         }
+      }
+
+      // No import matches and no wild-card/on-demand import matches means this class is in the same package.
+      if (Types.isSimpleName(result) && getPackage() != null)
+      {
+         result = getPackage() + "." + result;
+      }
+
+      return result;
+   }
+
+   private List<WildcardImportResolver> getImportResolvers()
+   {
+      if (resolvers == null)
+      {
+         resolvers = new ArrayList<>();
+         for (WildcardImportResolver r : ServiceLoader.load(WildcardImportResolver.class, getClass().getClassLoader()))
+         {
+            resolvers.add(r);
+         }
+      }
+      if (resolvers.isEmpty())
+      {
+         throw new IllegalStateException("No instances of [" + WildcardImportResolver.class.getName()
+                  + "] were found on the classpath.");
+      }
+      return resolvers;
+   }
+
+   private boolean validImport(final String type)
+   {
+      String className = Types.toSimpleName(type);
+      // check if this class name is equal to the class to import
+      if (className.equals(getName()))
+      {
+         return false;
+      }
+      // check if any import has the same class name
+      for (final Import imprt : getImports())
+      {
+         String importClassName = imprt.getSimpleName();
+         if (importClassName.equals(className))
+         {
+            return false;
+         }
+      }
+      return !Strings.isNullOrEmpty(type) && !Types.isPrimitive(type) && !Strings.isNullOrEmpty(Types.getPackage(type));
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O removeImport(final String name)
+   {
+      for (Import i : getImports())
+      {
+         if (i.getQualifiedName().equals(name))
+         {
+            removeImport(i);
+            break;
+         }
+      }
+      return (O) this;
+   }
+
+   @Override
+   public O removeImport(final Class<?> clazz)
+   {
+      return removeImport(clazz.getName());
+   }
+
+   @Override
+   public <T extends JavaType<?>> O removeImport(final T type)
+   {
+      return removeImport(type.getQualifiedName());
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O removeImport(final Import imprt)
+   {
+      Object internal = imprt.getInternal();
+      if (unit.imports().contains(internal))
+      {
+         unit.imports().remove(internal);
+      }
+      return (O) this;
+   }
+
+   // ================================================================================
+   // Naming
+   // ================================================================================
+
+   @Override
+   public String getCanonicalName()
+   {
+      String result = getName();
+
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
+      {
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
+         result = enclosingTypeLocal.getName() + "." + result;
+      }
+
+      if (!Strings.isNullOrEmpty(getPackage()))
+         result = getPackage() + "." + result;
+
+      return result;
+   }
+
+   /**
+    * Call-back to allow updating of any necessary internal names with the given name.
+    */
+   protected abstract O updateTypeNames(String name);
+
+   @Override
+   public String getQualifiedName()
+   {
+      String result = getName();
+
+      JavaType<?> enclosingTypeLocal = this;
+      while (enclosingTypeLocal != enclosingTypeLocal.getEnclosingType())
+      {
+         enclosingTypeLocal = enclosingTypeLocal.getEnclosingType();
+         result = enclosingTypeLocal.getName() + "$" + result;
+      }
+
+      if (!Strings.isNullOrEmpty(getPackage()))
+         result = getPackage() + "." + result;
+
+      return result;
+   }
+
+   // ================================================================================
+   // Package
+   // ================================================================================
+
+   @Override
+   public String getPackage()
+   {
+      PackageDeclaration pkg = unit.getPackage();
+      if (pkg != null)
+      {
+         return pkg.getName().getFullyQualifiedName();
+      }
+      return null;
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setPackage(final String name)
+   {
+      if (unit.getPackage() == null)
+      {
+         unit.setPackage(unit.getAST().newPackageDeclaration());
+      }
+      unit.getPackage().setName(unit.getAST().newName(name));
+      return (O) this;
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setDefaultPackage()
+   {
+      unit.setPackage(null);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isDefaultPackage()
+   {
+      return unit.getPackage() == null;
+   }
+
+   // ================================================================================
+   // String methods
+   // ================================================================================
+   /**
+    * Return this {@link JavaType} file as a String
+    */
+   @Override
+   public String toString()
+   {
+      return Formatter.format(toUnformattedString());
+   }
+
+   @Override
+   public String toUnformattedString()
+   {
+      Document documentLocal = new Document(this.document.get());
+
+      try
+      {
+         Map<String, String> options = JavaCore.getOptions();
+         options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
+         options.put(CompilerOptions.OPTION_Encoding, "UTF-8");
+         TextEdit edit = unit.rewrite(documentLocal, options);
+         edit.apply(documentLocal);
+      }
+      catch (Exception e)
+      {
+         throw new ParserException("Could not modify source: " + unit.toString(), e);
+      }
+
+      return documentLocal.get();
+   }
+
+   // ================================================================================
+   // Visibility
+   // ================================================================================
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setPackagePrivate()
+   {
+      modifiers.clearVisibility(getDeclaration());
+      return (O) this;
+   }
+
+   @Override
+   public boolean isPublic()
+   {
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setPublic()
+   {
+      modifiers.clearVisibility(getDeclaration());
+      modifiers.addModifier(getDeclaration(), ModifierKeyword.PUBLIC_KEYWORD);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isPrivate()
+   {
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setPrivate()
+   {
+      modifiers.clearVisibility(getDeclaration());
+      modifiers.addModifier(getDeclaration(), ModifierKeyword.PRIVATE_KEYWORD);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isProtected()
+   {
+      return modifiers.hasModifier(getDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setProtected()
+   {
+      modifiers.clearVisibility(getDeclaration());
+      modifiers.addModifier(getDeclaration(), ModifierKeyword.PROTECTED_KEYWORD);
+      return (O) this;
+   }
+
+   @Override
+   public boolean isPackagePrivate()
+   {
+      return !isPublic() && !isPrivate() && !isProtected();
+   }
+
+   @Override
+   public Visibility getVisibility()
+   {
+      return Visibility.getFrom(this);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O setVisibility(final Visibility scope)
+   {
+      return (O) Visibility.set(this, scope);
+   }
+
+   // ================================================================================
+   // Types
+   // ================================================================================
+
+   @Override
+   public boolean isClass()
+   {
+      ASTNode declaration = getDeclaration();
+      return (declaration instanceof TypeDeclaration)
+               && !((TypeDeclaration) declaration).isInterface();
+
+   }
+
+   @Override
+   public boolean isEnum()
+   {
+      ASTNode declaration = getDeclaration();
+      return declaration instanceof EnumDeclaration;
+   }
+
+   @Override
+   public boolean isInterface()
+   {
+      ASTNode declaration = getDeclaration();
+      return (declaration instanceof TypeDeclaration)
+               && ((TypeDeclaration) declaration).isInterface();
+   }
+
+   @Override
+   public boolean isAnnotation()
+   {
+      return getDeclaration() instanceof AnnotationTypeDeclaration;
+   }
+
+   // ================================================================================
+   // other
+   // ================================================================================
+
+   @Override
+   public JavaSource<?> getEnclosingType()
+   {
+      return enclosingType;
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (enclosingType == this)
+      {
+         return Objects.hash(document, unit);
+      }
+      return Objects.hash(document, enclosingType, unit);
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      AbstractJavaSource<?> other = (AbstractJavaSource<?>) obj;
+      if (document == null)
+      {
+         if (other.document != null)
+            return false;
+      }
+      else if (!document.equals(other.document))
+         return false;
+      if (enclosingType == null)
+      {
+         if (other.enclosingType != null)
+            return false;
+      }
+      else if (!enclosingType.equals(other.enclosingType))
+         return false;
+      if (unit == null)
+      {
+         if (other.unit != null)
+            return false;
+      }
+      else if (!unit.equals(other.unit))
+         return false;
+      return true;
+   }
+   
+   @Override
+   public Object getInternal()
+   {
+      return unit;
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public O getOrigin()
+   {
+      return (O) this;
+   }
+
+   @Override
+   public List<SyntaxError> getSyntaxErrors()
+   {
+      List<SyntaxError> result = new ArrayList<>();
+
+      IProblem[] problems = unit.getProblems();
+      if (problems != null)
+      {
+         for (IProblem problem : problems)
+         {
+            result.add(new SyntaxErrorImpl(this, problem));
+         }
+      }
+      return result;
+   }
+
+   @Override
+   public boolean hasSyntaxErrors()
+   {
+      return !getSyntaxErrors().isEmpty();
+   }
+
+   protected abstract ASTNode getDeclaration();
+}


### PR DESCRIPTION
Hi,
I've seen that JavaPackageInfoImpl contains a lot of duplicate code which can be avoided by creating a new abstract basis class for java sources. Both, JavaPackageInfoImpl and AbstractJavaSource now only containing only necessary methods while the base work is done JavaSourceImpl.

Because of such massive copy work the pr is quite big, while not changing any logic.

-- Kai