### PR TITLE
Remove more duplicate code

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSource.java
@@ -266,27 +266,14 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> extends JavaSo
    }
 
    @Override
-   public JavaDocSource<O> getJavaDoc()
+   protected Javadoc getJDTJavaDoc()
    {
-      Javadoc javadoc = body.getJavadoc();
-      if (javadoc == null)
-      {
-         javadoc = body.getAST().newJavadoc();
-         body.setJavadoc(javadoc);
-      }
-      return new JavaDocImpl<>((O) this, javadoc);
+      return body.getJavadoc();
    }
 
    @Override
-   public O removeJavaDoc()
+   protected void setJDTJavaDoc(Javadoc javaDoc)
    {
-      body.setJavadoc(null);
-      return (O) this;
-   }
-
-   @Override
-   public boolean hasJavaDoc()
-   {
-      return body.getJavadoc() != null;
+      body.setJavadoc(javaDoc);
    }
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -12,11 +12,11 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.text.edits.TextEdit;
 import org.jboss.forge.roaster.ParserException;
 import org.jboss.forge.roaster.model.JavaType;
-import org.jboss.forge.roaster.model.source.JavaDocSource;
 import org.jboss.forge.roaster.model.source.JavaPackageInfoSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.util.Formatter;
@@ -26,6 +26,7 @@ public class JavaPackageInfoImpl extends JavaSourceImpl<JavaPackageInfoSource>
 {
 
    private PackageDeclaration pkg;
+
    public JavaPackageInfoImpl(JavaSource<?> enclosingType, Document document,
             CompilationUnit unit, PackageDeclaration pkg)
    {
@@ -58,32 +59,6 @@ public class JavaPackageInfoImpl extends JavaSourceImpl<JavaPackageInfoSource>
    /*
     * Non-manipulation methods.
     */
-   /**
-    * Return this {@link JavaType} file as a String
-    */
-   @Override
-   public String toString()
-   {
-      return Formatter.format(toUnformattedString());
-   }
-
-   @Override
-   public String toUnformattedString()
-   {
-      Document documentLocal = new Document(this.document.get());
-
-      try
-      {
-         TextEdit edit = unit.rewrite(documentLocal, null);
-         edit.apply(documentLocal);
-      }
-      catch (Exception e)
-      {
-         throw new ParserException("Could not modify source: " + unit.toString(), e);
-      }
-
-      return documentLocal.get();
-   }
 
    @Override
    public int hashCode()
@@ -117,33 +92,20 @@ public class JavaPackageInfoImpl extends JavaSourceImpl<JavaPackageInfoSource>
    }
 
    @Override
-   public JavaDocSource<JavaPackageInfoSource> getJavaDoc()
-   {
-      Javadoc javadoc = pkg.getJavadoc();
-      if (javadoc == null)
-      {
-         javadoc = pkg.getAST().newJavadoc();
-         pkg.setJavadoc(javadoc);
-      }
-      return new JavaDocImpl<>(this, javadoc);
-   }
-
-   @Override
-   public JavaPackageInfoSource removeJavaDoc()
-   {
-      pkg.setJavadoc(null);
-      return this;
-   }
-
-   @Override
-   public boolean hasJavaDoc()
-   {
-      return pkg.getJavadoc() != null;
-   }
-
-   @Override
    protected JavaPackageInfoSource updateTypeNames(String name)
    {
-     throw new ParserException();
+      throw new ParserException();
+   }
+
+   @Override
+   protected Javadoc getJDTJavaDoc()
+   {
+      return pkg.getJavadoc();
+   }
+
+   @Override
+   protected void setJDTJavaDoc(Javadoc javaDoc)
+   {
+      pkg.setJavadoc(javaDoc);
    }
 }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaPackageInfoImpl.java
@@ -94,7 +94,7 @@ public class JavaPackageInfoImpl extends JavaSourceImpl<JavaPackageInfoSource>
    @Override
    protected JavaPackageInfoSource updateTypeNames(String name)
    {
-      throw new ParserException();
+      throw new UnsupportedOperationException("A package-info doesn't contain any types which can be updated");
    }
 
    @Override

--- a/impl/src/main/java/org/jboss/forge/roaster/model/util/Formatter.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/util/Formatter.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -196,9 +195,11 @@ public abstract class Formatter
    private static Properties readConfigInternal()
    {
       Properties properties = new Properties();
-      properties.setProperty(JavaCore.COMPILER_SOURCE, CompilerOptions.VERSION_1_8);
-      properties.setProperty(JavaCore.COMPILER_COMPLIANCE, CompilerOptions.VERSION_1_8);
-      properties.setProperty(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_8);
+
+      properties.setProperty(JavaCore.COMPILER_SOURCE, JDTOptions.getOption(JavaCore.COMPILER_SOURCE));
+      properties.setProperty(JavaCore.COMPILER_COMPLIANCE, JDTOptions.getOption(JavaCore.COMPILER_COMPLIANCE));
+      properties.setProperty(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM,
+               JDTOptions.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM));
       // ROASTER-96: Add a blank line after imports. "1" is equivalent to TRUE in the formatter XML file
       properties.setProperty(DefaultCodeFormatterConstants.FORMATTER_BLANK_LINES_AFTER_IMPORTS, "1");
       return properties;

--- a/impl/src/main/java/org/jboss/forge/roaster/model/util/JDTOptions.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/util/JDTOptions.java
@@ -1,7 +1,9 @@
 package org.jboss.forge.roaster.model.util;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Hashtable;
+import java.util.Map;
 
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -20,7 +22,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
  */
 public class JDTOptions
 {
-   private static Hashtable<String, String> OPTIONS = JavaCore.getOptions();
+   private static final Hashtable<String, String> OPTIONS = JavaCore.getOptions();
 
    static
    {
@@ -35,11 +37,23 @@ public class JDTOptions
       // Util class
    }
 
-   public static Hashtable<String, String> getJDTOptions()
+   /**
+    * Get all globally defined JDT options.
+    * 
+    * @return a map of all globally defined options as a unmodifiable map
+    * @see Collections#unmodifiableMap
+    */
+   public static Map<String, String> getJDTOptions()
    {
-      return OPTIONS;
+      return Collections.unmodifiableMap(OPTIONS);
    }
 
+   /**
+    * Get a certain JDT option.
+    * 
+    * @param option the option
+    * @return the value of the option or {@code null} if the option is not defined
+    */
    public static String getOption(String option)
    {
       return OPTIONS.get(option);

--- a/impl/src/main/java/org/jboss/forge/roaster/model/util/JDTOptions.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/util/JDTOptions.java
@@ -1,0 +1,47 @@
+package org.jboss.forge.roaster.model.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Hashtable;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+/**
+ * Global util class to get the current JDT parser options. The following options are guaranteed to be included:
+ * <ul>
+ * <li>{@link JavaCore#COMPILER_SOURCE}</li>
+ * <li>{@link JavaCore#CORE_ENCODING}</li>
+ * <li>{@link JavaCore#COMPILER_COMPLIANCE}</li>
+ * <li>{@link JavaCore#COMPILER_CODEGEN_TARGET_PLATFORM}</li>
+ * </ul>
+ * 
+ * @author Kai Mueller
+ *
+ */
+public class JDTOptions
+{
+   private static Hashtable<String, String> OPTIONS = JavaCore.getOptions();
+
+   static
+   {
+      OPTIONS.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+      OPTIONS.put(JavaCore.CORE_ENCODING, StandardCharsets.UTF_8.name());
+      OPTIONS.put(JavaCore.COMPILER_COMPLIANCE, CompilerOptions.VERSION_1_8);
+      OPTIONS.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_8);
+   }
+
+   private JDTOptions()
+   {
+      // Util class
+   }
+
+   public static Hashtable<String, String> getJDTOptions()
+   {
+      return OPTIONS;
+   }
+
+   public static String getOption(String option)
+   {
+      return OPTIONS.get(option);
+   }
+}

--- a/impl/src/main/java/org/jboss/forge/roaster/spi/JavaParserImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/spi/JavaParserImpl.java
@@ -7,11 +7,8 @@
 
 package org.jboss.forge.roaster.spi;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -43,6 +40,7 @@ import org.jboss.forge.roaster.model.source.JavaEnumSource;
 import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaPackageInfoSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
+import org.jboss.forge.roaster.model.util.JDTOptions;
 
 /**
  * The default implementation of a {@link JavaParser}.
@@ -59,7 +57,7 @@ public class JavaParserImpl implements JavaParser
       ASTParser parser = ASTParser.newParser(AST.JLS8);
 
       parser.setSource(document.get().toCharArray());
-      parser.setCompilerOptions(getParserOptions());
+      parser.setCompilerOptions(JDTOptions.getJDTOptions());
 
       parser.setResolveBindings(true);
       parser.setKind(ASTParser.K_COMPILATION_UNIT);
@@ -164,7 +162,7 @@ public class JavaParserImpl implements JavaParser
    {
       CodeSnippetParsingUtil codeSnippetParsingUtil = new CodeSnippetParsingUtil(false);
       ConstructorDeclaration constructorDeclaration = codeSnippetParsingUtil.parseStatements(snippet.toCharArray(), 0,
-               snippet.length(), getParserOptions(), true, false);
+               snippet.length(), JDTOptions.getJDTOptions(), true, false);
       CompilationResult compilationResult = constructorDeclaration.compilationResult();
       List<Problem> problems = new ArrayList<>();
       if (compilationResult.hasErrors())
@@ -179,13 +177,5 @@ public class JavaParserImpl implements JavaParser
          }
       }
       return problems;
-   }
-
-   private Hashtable<String, String> getParserOptions()
-   {
-      Hashtable<String, String> options = JavaCore.getOptions();
-      options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
-      options.put(JavaCore.CORE_ENCODING, StandardCharsets.UTF_8.name());
-      return options;
    }
 }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/util/JDTOptionsTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/util/JDTOptionsTest.java
@@ -1,0 +1,22 @@
+package org.jboss.forge.test.roaster.model.util;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.forge.roaster.model.util.JDTOptions;
+import org.junit.Test;
+
+public class JDTOptionsTest
+{
+
+   @Test
+   public void testGetJDTOptionsDoesNotReturnNull()
+   {
+      assertNotNull(JDTOptions.getJDTOptions());
+   }
+
+   @Test(expected = UnsupportedOperationException.class)
+   public void testGetJDTOptionsDoesReturnUnmodifiableMap()
+   {
+      JDTOptions.getJDTOptions().put("key", "value");
+   }
+}


### PR DESCRIPTION
Hi,
before I start to work on some more issues, I took some time to remove some more duplicate code. This includes the stuff I did two days ago via PR. Also I found, that the parser options are hardcoded in some files. So I created a util class in which the options are globally available. That also fixed a bug, where in one file still Java 1.7 was used instead of Java 1.8

Please review.

-- Kai