### PR TITLE
ROASTER-133: Improve the Import Impl.

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/source/Import.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/Import.java
@@ -36,9 +36,9 @@ public interface Import extends Internal, StaticCapableSource<Import>
 
    /**
     * Returns the qualified name, so it's the same as '{@code getPackage() + "." + getSimpleName()}'. In the case this
-    * is a wildcard import, the package part is returned.
+    * is a wildcard import, the whole import including a '*' at the end is returned.
     * 
-    * @return the qualified name or the packge if this is a wildcar import
+    * @return the qualified name or the full name if this is a wildcard import
     */
    String getQualifiedName();
 

--- a/api/src/main/java/org/jboss/forge/roaster/model/source/Importer.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/Importer.java
@@ -81,7 +81,7 @@ public interface Importer<O extends JavaSource<O>>
     * The resolving processing order is as followed:
     * <ol>
     * <li>If the type is primitive or full qualified, the type is returned as it</li>
-    * <li>Find the type in the imports</li>
+    * <li>Find the type in the imports with the simple name</li>
     * <li>If only one wildcard import is used, use this import for resolving</li>
     * <li>Use the available {@link WildcardImportResolver}. The first qualified name is used</li>
     * <li>The current package if defined is used for resolving</li>

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSourceMemberHolder.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/AbstractJavaSourceMemberHolder.java
@@ -401,9 +401,13 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
          if (Types.isSimpleName(rawName))
          {
             String pkg;
-            if (this.hasImport(rawName))
+            Import imprt = getImport(rawName);
+            if (imprt == null)
             {
-               Import imprt = this.getImport(rawName);
+               imprt = getImport(resolveType(rawName));
+            }
+            if (imprt != null)
+            {
                pkg = imprt.getPackage();
             }
             else
@@ -587,10 +591,11 @@ public abstract class AbstractJavaSourceMemberHolder<O extends JavaSource<O> & P
    @Override
    public final PropertySource<O> addProperty(String type, String name)
    {
-      if(hasProperty(name)) {
+      if (hasProperty(name))
+      {
          throw new IllegalStateException("Cannot create existing property " + name);
       }
-      
+
       O origin = getOrigin();
       if (origin.requiresImport(type))
       {

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/ImportImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/ImportImpl.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.jboss.forge.roaster.model.source.Import;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.util.Types;
@@ -48,12 +49,21 @@ public class ImportImpl implements Import
       {
          return WILDCARD;
       }
-      return Types.toSimpleName(imprt.getName().getFullyQualifiedName());
+      // if the name is simple it must be a wildcard import, handled one above
+      if (imprt.getName().isSimpleName())
+      {
+         throw new IllegalStateException("Unexpected simple name for an import");
+      }
+      return ((QualifiedName) imprt.getName()).getName().getFullyQualifiedName();
    }
 
    @Override
    public String getQualifiedName()
    {
+      if (isWildcard())
+      {
+         return imprt.getName().getFullyQualifiedName() + "." + WILDCARD;
+      }
       return imprt.getName().getFullyQualifiedName();
    }
 

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
@@ -255,7 +255,12 @@ public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSou
    {
       for (Import imprt : getImports())
       {
-         if (imprt.getQualifiedName().equals(className) || imprt.getSimpleName().equals(className))
+         String qualifiedName = imprt.getQualifiedName();
+         if(imprt.isWildcard()) {
+            qualifiedName = qualifiedName.substring(0, qualifiedName.length() -2); //remove .*
+         }
+
+         if (qualifiedName.equals(className))
          {
             return imprt;
          }
@@ -414,14 +419,16 @@ public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSou
          return "java.lang." + result;
       }
 
-      // Check for an existing direct import
-      Import directImport = getImport(result);
-      if (directImport != null)
-      {
-         return directImport.getQualifiedName();
-      }
-
       List<Import> imports = getImports(); // fetch imports only once
+      
+      //no need to check for a import with getImport becuase than a fqn name is needed
+      //search for an existing import with the same simple name
+      for(Import imprt : imports) {
+         if (imprt.getSimpleName().equals(result))
+         {
+            return imprt.getQualifiedName();
+         }
+      }
 
       // if we have no imports and no fqn name the following doesn't need to be executed
       if (!imports.isEmpty())
@@ -489,7 +496,7 @@ public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSou
       for (final Import imprt : getImports())
       {
          String importClassName = imprt.getSimpleName();
-         if (importClassName.equals(className))
+         if (!imprt.isWildcard() && importClassName.equals(className))
          {
             return false;
          }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/ImportTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/ImportTest.java
@@ -21,15 +21,49 @@ public class ImportTest
       assertThat(imprtOne).isNotNull();
       assertThat(imprtTwo).isNull();
    }
-   
+
    @Test
-   public void testWildCardImportReturnsCorrectData() {
+   public void testWildCardImportReturnsCorrectData()
+   {
       final JavaClassSource javaClassSource = Roaster.create(JavaClassSource.class);
       String pckage = "packageOne.packageTwo";
       final Import imprt = javaClassSource.addImport(pckage + ".*");
       assertThat(imprt.isWildcard(), is(true));
       assertThat(imprt.getPackage(), is(pckage));
       assertThat(imprt.getSimpleName(), is(Import.WILDCARD));
-      assertThat(imprt.getQualifiedName(), is(pckage));
+      assertThat(imprt.getQualifiedName(), is(pckage + ".*"));
+   }
+
+   @Test
+   public void testGetSimpleName()
+   {
+      final JavaClassSource javaClassSource = Roaster.create(JavaClassSource.class);
+
+      assertThat(javaClassSource.addImport("p1.Class2").getSimpleName(), is("Class2"));
+      assertThat(javaClassSource.addImport("p2.p3.Class3").getSimpleName(), is("Class3"));
+      assertThat(javaClassSource.addImport("p4.*").getSimpleName(), is(Import.WILDCARD));
+      assertThat(javaClassSource.addImport("p5.p6.*").getSimpleName(), is(Import.WILDCARD));
+   }
+
+   @Test
+   public void testGetPackage()
+   {
+      final JavaClassSource javaClassSource = Roaster.create(JavaClassSource.class);
+
+      assertThat(javaClassSource.addImport("p1.Class2").getPackage(), is("p1"));
+      assertThat(javaClassSource.addImport("p2.p3.Class3").getPackage(), is("p2.p3"));
+      assertThat(javaClassSource.addImport("p4.*").getPackage(), is("p4"));
+      assertThat(javaClassSource.addImport("p5.p6.*").getPackage(), is("p5.p6"));
+   }
+
+   @Test
+   public void testGetQualifiedName()
+   {
+      final JavaClassSource javaClassSource = Roaster.create(JavaClassSource.class);
+
+      assertThat(javaClassSource.addImport("p1.Class2").getQualifiedName(), is("p1.Class2"));
+      assertThat(javaClassSource.addImport("p2.p3.Class3").getQualifiedName(), is("p2.p3.Class3"));
+      assertThat(javaClassSource.addImport("p4.*").getQualifiedName(), is("p4.*"));
+      assertThat(javaClassSource.addImport("p5.p6.*").getQualifiedName(), is("p5.p6.*"));
    }
 }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/common/JavaClassTestBase.java
@@ -449,7 +449,7 @@ public abstract class JavaClassTestBase
       myClass.setSuperType("java.awt.List");
 
       assertEquals("Class should only contain one import.", 1, myClass.getImports().size());
-      assertEquals("Wrong import detected.", utilListImport, myClass.getImport("List"));
+      assertEquals("Wrong import detected.", utilListImport, myClass.getImport(myClass.resolveType("List")));
       assertEquals("Wrong super type set.", "java.awt.List", myClass.getSuperType());
    }
 


### PR DESCRIPTION
Hey,
I worked on an improvement on the import class (ImportImpl). It turned out more complicated and during the development I found other issues within the code.
In short words:
* getSimpleName now uses a more improved way
* getQualifiedName now returnes the full name instead of a package if a wildcard import is used
*  getImport now only works for fqn names (as the javadoc says) --> some changes needed therefore
* resolveType now checkes for simple name eq. in the imports
* validImport didn't worked for wildcard issues --> bug

BR,
Kai

