### PR TITLE
Fix import logic in setReturnType & addThrows

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/source/MethodSource.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/source/MethodSource.java
@@ -48,22 +48,38 @@ public interface MethodSource<O extends JavaSource<O>> extends Method<O, MethodS
    MethodSource<O> setNative(boolean value);
 
    /**
-    * Set this {@link Method} to return the given type.
+    * Set this {@link Method} to return the given type. The type is properly imported if possible.
+    * 
+    * @param type the return type
+    * @return this
+    * @see Importer#addImport(String)
     */
    MethodSource<O> setReturnType(final Class<?> type);
 
    /**
-    * Set this {@link Method} to return the given type.
+    * Set this {@link Method} to return the given type. The type is properly imported if possible.
+    * 
+    * @param type the return type
+    * @return this
+    * @see Importer#addImport(String)
     */
    MethodSource<O> setReturnType(final String type);
 
    /**
-    * Set this {@link Method} to return the given {@link JavaType} type.
+    * Set this {@link Method} to return the given type. The type is properly imported if possible.
+    * 
+    * @param type the return type
+    * @return this
+    * @see Importer#addImport(String)
     */
    MethodSource<O> setReturnType(JavaType<?> type);
 
    /**
-    * Set this {@link Method} to return the given {@link Type}
+    * Set this {@link Method} to return the given type. The type is properly imported if possible.
+    * 
+    * @param type the return type
+    * @return this
+    * @see Importer#addImport(String)
     */
    MethodSource<O> setReturnType(Type<?> type);
 

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/JavaSourceImpl.java
@@ -222,18 +222,20 @@ public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSou
    @Override
    public Import addImport(final String className)
    {
-      String strippedClassName = Types.stripGenerics(Types.stripArray(className));
+      String strippedClassName = Types.stripArray(className);
 
       if (Types.isGeneric(className))
       {
          for (String genericPart : Types.splitGenerics(className))
          {
-            if (Types.isQualified(genericPart))
+         // a type variable is not qualified, so it won't be imported by accident
+            if (Types.isQualified(genericPart)) 
                addImport(genericPart);
          }
       }
-
+      
       // test this after generics are imported
+      strippedClassName = Types.stripGenerics(strippedClassName);
       if (!Types.isQualified(strippedClassName) || Types.isJavaLang(strippedClassName))
       {
          return null;
@@ -257,6 +259,8 @@ public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSou
    @Override
    public Import getImport(final String className)
    {
+      String strippedClassName = Types.stripArray(Types.stripGenerics(className));
+      
       for (Import imprt : getImports())
       {
          String qualifiedName = imprt.getQualifiedName();
@@ -265,7 +269,7 @@ public abstract class JavaSourceImpl<O extends JavaSource<O>> implements JavaSou
             qualifiedName = qualifiedName.substring(0, qualifiedName.length() - 2); // remove .*
          }
 
-         if (qualifiedName.equals(className))
+         if (qualifiedName.equals(strippedClassName))
          {
             return imprt;
          }

--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/MethodImpl.java
@@ -656,8 +656,8 @@ public class MethodImpl<O extends JavaSource<O>> implements MethodSource<O>
    @SuppressWarnings({ "unchecked", "rawtypes" })
    public MethodSource<O> addThrows(final String type)
    {
-      Import imprt = getOrigin().addImport(type);
-      String typeToUse = imprt != null ? imprt.getSimpleName() : type;
+      getOrigin().addImport(type);
+      String typeToUse = Types.toResolvedType(type, getOrigin());
       Name name = method.getAST().newName(typeToUse);
 
       List list = (List) method.getStructuralProperty(MethodDeclaration.THROWN_EXCEPTION_TYPES_PROPERTY);

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/util/TypesTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/util/TypesTest.java
@@ -7,9 +7,11 @@
 
 package org.jboss.forge.test.roaster.model.util;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -27,6 +29,27 @@ import org.junit.Test;
  */
 public class TypesTest
 {
+   @Test
+   public void testGetArraySuffix()
+   {
+      assertThat(Types.getArraySuffix(""), is(""));
+      assertThat(Types.getArraySuffix("String"), is(""));
+      assertThat(Types.getArraySuffix("String[]"), is("[]"));
+      assertThat(Types.getArraySuffix("String[][]"), is("[][]"));
+   }
+
+   @Test
+   public void testToResolvedType()
+   {
+      JavaClassSource classSource = Roaster.create(JavaClassSource.class);
+      classSource.addImport("c1.OuterClass");
+      classSource.addImport("g2.SecondGeneric");
+
+      String toResolved = "c1.OuterClass<g1.FirstGeneric,g2.SecondGeneric<java.lang.String>>[][]";
+      String expected = "OuterClass<g1.FirstGeneric,SecondGeneric<String>>[][]";
+      assertThat(Types.toResolvedType(toResolved, classSource), is(expected));
+   }
+
    @Test
    public void testIsBasicType()
    {


### PR DESCRIPTION
Hi,
I found some more wrongly assumes imports in setReturnType & addThrows. To be able to implement this, I added two new helper function inside Types. I think _toResolvedType_ is a really helpful method and should be used in other areas where currently own logic is implemented.

In addition, I found some issues in
* isJavaLang
* addImport
* getImport

BR,
Kai