### PR TITLE
ROASTER-135: Fix wildcard handling in Types.toResolvedType

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,12 @@
 name: GitHub CI
 
-on: [push]
+on: 
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
 
 jobs:
   Build:

--- a/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/Types.java
@@ -310,9 +310,14 @@ public class Types
          StringJoiner genericJoiner = new StringJoiner(",");
          for (String genericPart : splitGenerics(type))
          {
-            genericJoiner.add(toResolvedType(genericPart, importer));
+            String resolved = toResolvedType(genericPart, importer);
+            resolved = resolved.replace("?extends", "? extends ");
+            resolved = resolved.replace("?super", "? super ");
+            genericJoiner.add(resolved);
          }
+
          builder.append("<").append(genericJoiner.toString()).append(">");
+
       }
 
       return builder.append(getArraySuffix(type)).toString();

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,5 +29,11 @@
          <version>3.16.0</version>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <version>3.3.3</version>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 </project>

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/util/TypesTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/util/TypesTest.java
@@ -12,6 +12,7 @@ import java.util.Vector;
 
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.Type;
+import org.jboss.forge.roaster.model.source.Importer;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.util.Types;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -372,5 +375,17 @@ public class TypesTest
    public void testToSplitGenericsFailesIfArgumentIsNull()
    {
       assertThrows(NullPointerException.class, () -> Types.splitGenerics(null));
+   }
+
+   // ROASTER-135
+   @Test
+   public void testToHandleWildardsInToResolvedType()
+   {
+      Importer<?> importer = mock(Importer.class);
+
+      when(importer.getImport("List<? extends Account>")).thenReturn(null);
+      when(importer.getImport("?extendsAccount")).thenReturn(null);
+
+      assertEquals("List<? extends Account>", Types.toResolvedType("List<? extends Account>", importer));
    }
 }


### PR DESCRIPTION
This commit fixes the handling of types like List<? extends Number> in Types.toResolvedType.