### PR TITLE
Build fix with jdk 11 and commons-lang3 

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -84,6 +84,7 @@
                   <artifact>org.apache.commons:commons-lang3</artifact>
                   <includes>
                     <include>org/apache/commons/lang3/StringUtils**</include>
+                    <include>org/apache/commons/lang3/CharSequenceUtils**</include>
                     <include>org/apache/commons/lang3/ArrayUtils**</include>
                     <include>org/apache/commons/lang3/Range**</include>
                     <include>org/apache/commons/lang3/Validate**</include>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -84,6 +84,7 @@
                   <artifact>org.apache.commons:commons-lang3</artifact>
                   <includes>
                     <include>org/apache/commons/lang3/StringUtils**</include>
+                    <include>org/apache/commons/lang3/ArrayUtils**</include>
                     <include>org/apache/commons/lang3/Range**</include>
                     <include>org/apache/commons/lang3/Validate**</include>
                   </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
   </developers>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
     <version.commons-text>1.9</version.commons-text>


### PR DESCRIPTION
I was using roaster as a dependency and I had both commons-lang3 and roaster. When I tried to use StringUtils.equalsAny or startsWithAny, I got NoClassDefFoundError on ArrayUtils and CharsequenceUtils. I added them in the includes.
Of course I could very well use the original commons-lang3 instead but I realized that having both as a dependency inevitably leads to importing the wrong one accidentally. So for me it made more sense to fix the broken commons-lang3 from roaster. Or course, other methods could be broken too due to missing includes.
After fixing that, I had a build issue because one of the eclipse jars is compiled in jdk 11 so I changed java compiler version to 11.