### PR TITLE
fix(sec): upgrade org.apache.commons:commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
-    <version.commons-text>1.9</version.commons-text>
+    <version.commons-text>1.10.0</version.commons-text>
     <version.surefire.plugin>3.0.0-M3</version.surefire.plugin>
   </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-text 1.9
- [CVE-2022-42889](https://www.oscs1024.com/hd/CVE-2022-42889)


### What did I do？
Upgrade org.apache.commons:commons-text from 1.9 to 1.10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS