### PR TITLE
Fix multi-field name parsing

### DIFF
--- a/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
+++ b/impl/src/main/java/org/jboss/forge/roaster/model/impl/FieldImpl.java
@@ -291,17 +291,7 @@ public class FieldImpl<O extends JavaSource<O>> implements FieldSource<O>
    @Override
    public String getName()
    {
-      String result = null;
-      for (Object f : field.fragments())
-      {
-         if (f instanceof VariableDeclarationFragment)
-         {
-            VariableDeclarationFragment frag = (VariableDeclarationFragment) f;
-            result = frag.getName().getFullyQualifiedName();
-            break;
-         }
-      }
-      return result;
+      return fragment.getName().getFullyQualifiedName();
    }
 
    @Override

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/FieldMultipleTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/FieldMultipleTest.java
@@ -13,6 +13,7 @@ import org.jboss.forge.roaster.model.source.FieldSource;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -125,4 +126,10 @@ public class FieldMultipleTest
       assertEquals(1, fields.get(2).getType().getArrayDimensions());
    }
 
+    @Test
+    public void testMultipleFieldDeclarationParse()
+    {
+        JavaClassSource javaClassSource = Roaster.parse(JavaClassSource.class, "public class Test { private String a,b; }");
+        assertThat(javaClassSource.getFields()).hasSize(2).extracting(FieldSource::getName).containsExactly("a", "b");
+    }
 }


### PR DESCRIPTION
- Update test suite to include validation for multiple field declarations using AssertJ.
- Refactor `getName` method in `FieldImpl` for more efficient retrieval of fully qualified names.
- Fixes #339
