### PR TITLE
Harden FormatterProfileReader against XXE and entity expansion attacks

### DIFF
--- a/api/src/main/java/org/jboss/forge/roaster/model/util/FormatterProfileReader.java
+++ b/api/src/main/java/org/jboss/forge/roaster/model/util/FormatterProfileReader.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -54,6 +55,12 @@ public class FormatterProfileReader
 
       try
       {
+         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+         factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+         factory.setXIncludeAware(false);
          SAXParser parser = factory.newSAXParser();
          parser.parse(new InputSource(inputStream), handler);
       }

--- a/tests/src/test/java/org/jboss/forge/test/roaster/model/util/FormatterProfileReaderTest.java
+++ b/tests/src/test/java/org/jboss/forge/test/roaster/model/util/FormatterProfileReaderTest.java
@@ -7,13 +7,16 @@
 
 package org.jboss.forge.test.roaster.model.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.forge.roaster.model.util.FormatterProfileReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -41,6 +44,34 @@ public class FormatterProfileReaderTest
          assertNull(reader.getPropertiesFor("Something Else"));
          assertNotNull(reader.getDefaultProperties());
       }
+   }
+
+   @Test
+   public void testXXEAttackIsBlocked()
+   {
+      String xxePayload = "<?xml version=\"1.0\"?>\n"
+               + "<!DOCTYPE profiles [\n"
+               + "  <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n"
+               + "]>\n"
+               + "<profiles>&xxe;</profiles>";
+      InputStream input = new ByteArrayInputStream(xxePayload.getBytes(StandardCharsets.UTF_8));
+      assertThatThrownBy(() -> FormatterProfileReader.fromEclipseXml(input))
+               .isInstanceOf(IOException.class);
+   }
+
+   @Test
+   public void testBillionLaughsAttackIsBlocked()
+   {
+      String billionLaughs = "<?xml version=\"1.0\"?>\n"
+               + "<!DOCTYPE profiles [\n"
+               + "  <!ENTITY a \"aaaaaaaaaa\">\n"
+               + "  <!ENTITY b \"&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;\">\n"
+               + "  <!ENTITY c \"&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;\">\n"
+               + "]>\n"
+               + "<profiles>&c;</profiles>";
+      InputStream input = new ByteArrayInputStream(billionLaughs.getBytes(StandardCharsets.UTF_8));
+      assertThatThrownBy(() -> FormatterProfileReader.fromEclipseXml(input))
+               .isInstanceOf(IOException.class);
    }
 
    @Test


### PR DESCRIPTION
## Summary

- Harden `SAXParserFactory` in `FormatterProfileReader` to prevent XXE (CWE-611) and billion-laughs entity expansion (CWE-776) attacks
- Add tests verifying that XXE and entity expansion payloads are rejected

Fixes #399

## Test plan

- [x] `testXXEAttackIsBlocked` — verifies external entity payloads are rejected with `IOException`
- [x] `testBillionLaughsAttackIsBlocked` — verifies entity expansion payloads are rejected with `IOException`
- [x] Existing `testFormatterProfileReaderTwoProfiles` and `testFormatterProfileReaderOneProfile` still pass